### PR TITLE
Depreciated client.sendToChannel function

### DIFF
--- a/packages/fluxer-core/src/client/Client.ts
+++ b/packages/fluxer-core/src/client/Client.ts
@@ -283,11 +283,16 @@ export class Client extends EventEmitter {
   /**
    * Send a message to any channel by ID. Shorthand for client.channels.send().
    * Works even when the channel is not cached.
+   * @deprecated Use client.channels.send(channelId, payload).
    */
   async sendToChannel(
     channelId: string,
     content: string | { content?: string; embeds?: APIEmbed[] },
   ): Promise<Message> {
+    emitDeprecationWarning(
+      'Client.sendToChannel()',
+      'Use client.channels.send(channelId, payload).',
+    );
     const payload = await Message._createMessageBody(content);
     return this.channels.send(channelId, payload);
   }


### PR DESCRIPTION
## Description

Depreciated client.sendToChannel function as its outdated and prompted to use client.channels.send(channelId, payload) instead.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] My code follows the project's style guidelines (run `pnpm run lint`)
- [x] I have run `pnpm run build` successfully
- [x] I have run `pnpm run test` successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecations**
  * Client.sendToChannel() is now deprecated. Migrate to client.channels.send() for future compatibility. Deprecation warnings will be emitted when using the old method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->