### PR TITLE
fix(ws): add gateway close code 4013 (AckBackpressure) and mark as re…

### DIFF
--- a/.changeset/fix-ack-backpressure-4013.md
+++ b/.changeset/fix-ack-backpressure-4013.md
@@ -1,0 +1,13 @@
+---
+'@fluxerjs/ws': patch
+---
+
+fix(ws): add gateway close code 4013 (AckBackpressure) and mark as reconnectable
+
+The Fluxer gateway sends close code 4013 (`ack_backpressure`) when the
+session's event acknowledgement buffer overflows. This is a transient
+condition (the server had too many unacknowledged events queued) and is
+safe to reconnect after.
+
+- Add `AckBackpressure: 4013` to `GatewayCloseCodes`
+- Add `case 4013` to `shouldReconnectOnClose()` so the shard auto-reconnects

--- a/packages/ws/src/WebSocketShard.ts
+++ b/packages/ws/src/WebSocketShard.ts
@@ -287,6 +287,7 @@ function shouldReconnectOnClose(code: number): boolean {
     case 4010: // Invalid shard
     case 4011: // Sharding required
     case 4012: // Invalid API version (after fix, reconnect is safe)
+    case 4013: // Ack backpressure (server event buffer full; transient, safe to retry)
       return true;
     default:
       return false;

--- a/packages/ws/src/utils/constants.test.ts
+++ b/packages/ws/src/utils/constants.test.ts
@@ -14,6 +14,7 @@ describe('GatewayCloseCodes', () => {
     expect(GatewayCloseCodes.AuthenticationFailed).toBe(4004);
     expect(GatewayCloseCodes.RateLimited).toBe(4008);
     expect(GatewayCloseCodes.InvalidShard).toBe(4010);
+    expect(GatewayCloseCodes.AckBackpressure).toBe(4013);
   });
 
   it('has all expected keys', () => {
@@ -36,6 +37,7 @@ describe('GatewayCloseCodes', () => {
       'InvalidShard',
       'ShardingRequired',
       'InvalidAPIVersion',
+      'AckBackpressure',
     ];
     for (const key of expected) {
       expect(GatewayCloseCodes).toHaveProperty(key);

--- a/packages/ws/src/utils/constants.ts
+++ b/packages/ws/src/utils/constants.ts
@@ -18,4 +18,5 @@ export const GatewayCloseCodes = {
   InvalidShard: 4010,
   ShardingRequired: 4011,
   InvalidAPIVersion: 4012,
+  AckBackpressure: 4013,
 } as const;


### PR DESCRIPTION
## Description

The Fluxer gateway sends close code 4013 (`ack_backpressure`) when the session's
event acknowledgement buffer overflows (>4096 unacked events). This is a transient
condition and its safe to reconnect after, but [shouldReconnectOnClose()](cci:1://file:///home/dogbone/Clone/fluxy/documentation/@fluxerjs/core/packages/ws/src/WebSocketShard.ts:270:0-294:1) doesn't include it, causing shards to silently die instead of auto-reconnecting.

This adds:
- `AckBackpressure: 4013` to `GatewayCloseCodes`
- `case 4013` to [shouldReconnectOnClose()](cci:1://file:///home/dogbone/Clone/fluxy/documentation/@fluxerjs/core/packages/ws/src/WebSocketShard.ts:270:0-294:1) so that the shard reconnects automatically

Ref: `fluxer_gateway/src/utils/constants.erl` `close_code_to_num(ack_backpressure) -> 4013`

## Type of change

- [x] Bug fix

## Checklist

- [x] My code follows the project's style guidelines (run `pnpm run lint`)
- [x] I have run `pnpm run build` successfully
- [x] I have run `pnpm run test` successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket connection reliability by adding automatic reconnection support for gateway acknowledgment backpressure scenarios. When the gateway indicates backpressure conditions during high-load periods, the system will now automatically reconnect, reducing service interruptions and enhancing connection stability. This ensures more consistent and reliable connectivity during demanding usage scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->