### PR TITLE
feat(core): add GuildMember.move() method for managing voice channels

### DIFF
--- a/.changeset/add-guildmember-move-method.md
+++ b/.changeset/add-guildmember-move-method.md
@@ -1,0 +1,22 @@
+---
+'@fluxerjs/core': minor
+---
+
+feat(core): add GuildMember.move() method for moving members between voice channels :>
+
+Adds a new `move()` method to the `GuildMember` class that provides an easy way to move members between voice channels or disconnect them from voice.
+
+This method wraps the existing `edit()` functionality with a cleaner API similar to d.js:
+
+```ts
+// moves member to a different voice channel
+await member.move('123456789012345678');
+
+// disconnect said member from voice
+await member.move(null);
+
+// move with specific connection ID
+await member.move('123456789012345678', 'connection-id');
+```
+
+The method requires the `MOVE_MEMBERS` permission and will throw appropriate errors if the member is not in voice or if permissions are missing.

--- a/packages/fluxer-core/src/structures/GuildMember.test.ts
+++ b/packages/fluxer-core/src/structures/GuildMember.test.ts
@@ -129,4 +129,66 @@ describe('GuildMember', () => {
       expect(url).toContain('avatars/u1/useravatar');
     });
   });
+
+  describe('move()', () => {
+    it('calls edit with channel_id to move member', async () => {
+      const member = createMember();
+      let editCalled: boolean = false;
+      let editParams: { channel_id: string | null; connection_id?: string | null } | undefined;
+
+      member.edit = async (params: { channel_id: string | null; connection_id?: string | null }) => {
+        editCalled = true;
+        editParams = params;
+        return member;
+      };
+
+      await member.move('voicechannel123');
+
+      expect(editCalled).toBe(true);
+      expect(editParams).toEqual({
+        channel_id: 'voicechannel123',
+        connection_id: undefined,
+      });
+    });
+
+    it('calls edit with null to disconnect member', async () => {
+      const member = createMember();
+      let editCalled: boolean = false;
+      let editParams: { channel_id: string | null; connection_id?: string | null } | undefined;
+
+      member.edit = async (params: { channel_id: string | null; connection_id?: string | null }) => {
+        editCalled = true;
+        editParams = params;
+        return member;
+      };
+
+      await member.move(null);
+
+      expect(editCalled).toBe(true);
+      expect(editParams).toEqual({
+        channel_id: null,
+        connection_id: undefined,
+      });
+    });
+
+    it('calls edit with connection_id when provided', async () => {
+      const member = createMember();
+      let editCalled: boolean = false;
+      let editParams: { channel_id: string | null; connection_id?: string | null } | undefined;
+
+      member.edit = async (params: { channel_id: string | null; connection_id?: string | null }) => {
+        editCalled = true;
+        editParams = params;
+        return member;
+      };
+
+      await member.move('voicechannel123', 'connection456');
+
+      expect(editCalled).toBe(true);
+      expect(editParams).toEqual({
+        channel_id: 'voicechannel123',
+        connection_id: 'connection456',
+      });
+    });
+  });
 });

--- a/packages/fluxer-core/src/structures/GuildMember.ts
+++ b/packages/fluxer-core/src/structures/GuildMember.ts
@@ -179,6 +179,26 @@ export class GuildMember extends Base {
     return new BitField<keyof typeof PermissionFlags>(perms);
   }
 
+  /**
+   * Move this member to a different voice channel or disconnect them from voice.
+   * Requires Move Members permission.
+   * @param channelId - The voice channel ID to move the member to, or null to disconnect
+   * @param connectionId - Optional connection ID for the specific voice session (usually not needed)
+   * @returns Promise that resolves when the member has been moved
+   * @example
+   * // Move member to a different voice channel
+   * await member.move('123456789012345678');
+   *
+   * // Disconnect member from voice
+   * await member.move(null);
+   */
+  async move(channelId: string | null, connectionId?: string | null): Promise<void> {
+    await this.edit({
+      channel_id: channelId,
+      connection_id: connectionId,
+    });
+  }
+
   private _computeBasePermissions(): bigint {
     let base = 0n;
     const everyone = this.guild.roles.get(this.guild.id);


### PR DESCRIPTION
Adding a convenient move() method to the GuildMember class that allows easily moving members between voice channels or disconnecting them. 

## Description

Adds a new `move()` method to the `GuildMember` class.  
This method wraps the existing `edit()` functionality, providing a simple API to move a member to a different voice channel or disconnect them from voice.  
It improves parity with d.js and makes voice management of regular users easier to perform.

## Type of change

- [x] New feature

## Checklist

- [x] My code follows the project's style guidelines (run `pnpm run lint`)
- [x] I have run `pnpm run build` successfully
- [x] I have run `pnpm run test` successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `GuildMember.move()` method to simplify moving guild members between voice channels or disconnecting them. Supports passing `null` to disconnect and an optional connection ID parameter. Requires `MOVE_MEMBERS` permission.

* **Tests**
  * Added comprehensive test coverage for the new `move()` method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->