### PR TITLE
export client options

### DIFF
--- a/packages/fluxer-core/src/index.ts
+++ b/packages/fluxer-core/src/index.ts
@@ -83,3 +83,4 @@ export {
   cdnDefaultAvatarURL,
 } from './util/cdn.js';
 export type { CdnUrlOptions } from './util/cdn.js';
+export type { ClientOptions, CacheSizeLimits } from './util/Options.js';


### PR DESCRIPTION
## Description

<!-- Describe your changes -->
Export `ClientOptions` and `CacheSizeLimits`, It's important to be able to access the `ClientOptions` when extending or modifying the client such as building another framework library on top of Fluxer.js, it is also exported in Discord.js

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] My code follows the project's style guidelines (run `pnpm run lint`)
- [x] I have run `pnpm run build` successfully
- [x] I have run `pnpm run test` successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Core package now exports additional TypeScript types for client configuration and cache size limits, improving type safety and developer experience when configuring the library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->