### PR TITLE
fix: voice state update & sync types

### DIFF
--- a/packages/fluxer-core/src/client/Client.ts
+++ b/packages/fluxer-core/src/client/Client.ts
@@ -562,7 +562,7 @@ export class Client extends EventEmitter {
           this.guilds.set(guild.id, guild);
           const withCh = g as APIGuild & {
             channels?: APIChannel[];
-            voice_states?: Array<{ user_id: string; channel_id: string | null }>;
+            voice_states?: Array<GatewayVoiceStateUpdateDispatchData>;
           };
           for (const ch of withCh.channels ?? []) {
             const channel = Channel.from(this, ch);

--- a/packages/fluxer-core/src/client/Client.ts
+++ b/packages/fluxer-core/src/client/Client.ts
@@ -108,7 +108,7 @@ export interface ClientEvents {
   [Events.VoiceStateUpdate]: [data: GatewayVoiceStateUpdateDispatchData];
   [Events.VoiceServerUpdate]: [data: GatewayVoiceServerUpdateDispatchData];
   [Events.VoiceStatesSync]: [
-    data: { guildId: string; voiceStates: Array<{ user_id: string; channel_id: string | null }> },
+    data: { guildId: string; voiceStates: Array<GatewayVoiceStateUpdateDispatchData> },
   ];
   [Events.MessageDeleteBulk]: [data: GatewayMessageDeleteBulkDispatchData];
   [Events.GuildBanAdd]: [ban: GuildBan];

--- a/packages/fluxer-core/src/client/EventHandlerRegistry.ts
+++ b/packages/fluxer-core/src/client/EventHandlerRegistry.ts
@@ -178,7 +178,7 @@ handlers.set('GUILD_CREATE', async (client, d) => {
   client.guilds.set(guild.id, guild);
   const g = d as APIGuild & {
     channels?: APIChannel[];
-    voice_states?: Array<{ user_id: string; channel_id: string | null }>;
+    voice_states?: Array<GatewayVoiceStateUpdateDispatchData>;
     members?: Array<APIGuildMember & { user: { id: string }; guild_id?: string }>;
   };
   for (const ch of g.channels ?? []) {

--- a/packages/types/src/gateway/payloads.ts
+++ b/packages/types/src/gateway/payloads.ts
@@ -300,21 +300,25 @@ export interface GatewayGuildRoleUpdateBulkDispatchData {
 
 /** VOICE_STATE_UPDATE — guild_id?, channel_id, user_id, member?, session_id, deaf?, mute?, ... */
 export interface GatewayVoiceStateUpdateDispatchData {
-  guild_id?: Snowflake;
   channel_id: Snowflake | null;
-  user_id: Snowflake;
-  member?: APIGuildMember & { guild_id?: Snowflake };
-  session_id: string;
   /** Connection ID for voice session (Fluxer). */
-  connection_id?: string | null;
-  deaf?: boolean;
-  mute?: boolean;
-  self_deaf?: boolean;
-  self_mute?: boolean;
-  self_video?: boolean;
+  connection_id: string;
+  deaf: boolean;
+  e2ee_capable: boolean;
+  guild_id: Snowflake;
+  is_mobile: boolean;
+  member: APIGuildMember;
+  mute: boolean;
+  self_deaf: boolean;
+  self_mute: boolean;
   /** Whether the user is screen sharing / streaming. */
-  self_stream?: boolean;
-  suppress?: boolean;
+  self_stream: boolean;
+  self_video: boolean;
+  session_id: string;
+  suppress: boolean;
+  user_id: Snowflake;
+  version: number;
+  viewer_stream_keys: string[];
 }
 
 /** VOICE_SERVER_UPDATE — token, guild_id, endpoint, connection_id? */

--- a/packages/voice/src/LiveKitRtcConnection.ts
+++ b/packages/voice/src/LiveKitRtcConnection.ts
@@ -5,7 +5,6 @@ import { VoiceChannel } from '@fluxerjs/core';
 import { ErrorCodes, FluxerError } from '@fluxerjs/util';
 import {
   GatewayVoiceServerUpdateDispatchData,
-  GatewayVoiceStateUpdateDispatchData,
 } from '@fluxerjs/types';
 import {
   AudioStream,
@@ -472,11 +471,9 @@ export class LiveKitRtcConnection extends EventEmitter {
    * Called internally by VoiceManager; typically not used directly.
    *
    * @param server - Voice server update data (endpoint, token)
-   * @param _state - Voice state update data (session, channel)
    */
   async connect(
     server: GatewayVoiceServerUpdateDispatchData,
-    _state: GatewayVoiceStateUpdateDispatchData,
   ): Promise<void> {
     const raw = (server.endpoint ?? '').trim();
     const token = server.token;

--- a/packages/voice/src/VoiceConnection.ts
+++ b/packages/voice/src/VoiceConnection.ts
@@ -4,7 +4,6 @@ import { VoiceChannel } from '@fluxerjs/core';
 import { ErrorCodes, FluxerError } from '@fluxerjs/util';
 import {
   GatewayVoiceServerUpdateDispatchData,
-  GatewayVoiceStateUpdateDispatchData,
 } from '@fluxerjs/types';
 import * as nacl from 'tweetnacl';
 import * as dgram from 'dgram';
@@ -112,11 +111,11 @@ export class VoiceConnection extends EventEmitter {
   /** Called when we have both server update and state update. */
   async connect(
     server: GatewayVoiceServerUpdateDispatchData,
-    state: GatewayVoiceStateUpdateDispatchData,
+    sessionId: string,
   ): Promise<void> {
     this._token = server.token;
     const raw = (server.endpoint ?? '').trim();
-    this._sessionId = state.session_id;
+    this._sessionId = sessionId;
     if (!raw || !this._token || !this._sessionId) {
       this.emit('error', new Error('Missing voice server or session data'));
       return;

--- a/packages/voice/src/VoiceManager.ts
+++ b/packages/voice/src/VoiceManager.ts
@@ -227,14 +227,7 @@ export class VoiceManager extends EventEmitter {
     const newConn = new ConnClass(this.client, channel, userId);
     this.registerConnection(channel.id, newConn);
 
-    const state: GatewayVoiceStateUpdateDispatchData = {
-      guild_id: guildId,
-      channel_id: channel.id,
-      user_id: userId,
-      session_id: '',
-    };
-
-    newConn.connect(data, state).catch((e) => {
+    newConn.connect(data).catch((e) => {
       this.connections.delete(channel.id);
       newConn.emit('error', e instanceof Error ? e : new Error(String(e)));
     });
@@ -315,23 +308,17 @@ export class VoiceManager extends EventEmitter {
       return;
     }
 
-    const guildId = pending.channel?.guildId ?? '';
-    const state: GatewayVoiceStateUpdateDispatchData = pending.state ?? {
-      guild_id: guildId,
-      channel_id: pending.channel.id,
-      user_id: userId,
-      session_id: '',
-    };
+    const connectionId = pending.server.connection_id ?? pending.state?.connection_id ?? "";
 
     this.storeConnectionId(
       channelId,
-      pending.server.connection_id ?? (state as { connection_id?: string }).connection_id,
+      connectionId,
     );
     this.pending.delete(channelId);
     const ConnClass = useLiveKit ? LiveKitRtcConnection : VoiceConnection;
     const conn = new ConnClass(this.client, pending.channel, userId);
     this.registerConnection(channelId, conn);
-    conn.connect(pending.server, state).then(
+    conn.connect(pending.server, connectionId).then(
       () => pending.resolve(conn),
       (e) => pending.reject(e),
     );


### PR DESCRIPTION
## Description

fixes #33

true data from Fluxer:
```js
// leaving a voice channel (via VoiceStateUpdate)
{
  channel_id: null,
  connection_id: "borrelly-reedfish",
  deaf: false,
  e2ee_capable: false,
  guild_id: "1469282594141373123",
  is_mobile: false,
  member: [Object ...],
  mute: false,
  self_deaf: false,
  self_mute: true,
  self_stream: false,
  self_video: false,
  session_id: "A6315196538C4CAF68F12D94B447154C",
  suppress: false,
  user_id: "1469282305648751275",
  version: 0,
  viewer_stream_keys: [],
}

// joining a voice channel (via VoiceStateUpdate)
{
  channel_id: "1469282594141373127",
  connection_id: "yak-smoot",
  deaf: false,
  e2ee_capable: false,
  guild_id: "1469282594141373123",
  is_mobile: false,
  member: [Object ...],
  mute: false,
  self_deaf: false,
  self_mute: true,
  self_stream: false,
  self_video: false,
  session_id: "A6315196538C4CAF68F12D94B447154C",
  suppress: false,
  user_id: "1469282305648751275",
  version: 0,
  viewer_stream_keys: [],
}

// VoiceStateSync
{
  guildId: "1469282594141373123",
  voiceStates: [
    {
      channel_id: "1469282594141373127",
      connection_id: "borrelly-reedfish",
      deaf: false,
      e2ee_capable: false,
      guild_id: "1469282594141373123",
      is_mobile: false,
      member: [Object ...],
      mute: false,
      self_deaf: false,
      self_mute: true,
      self_stream: false,
      self_video: false,
      session_id: "A6315196538C4CAF68F12D94B447154C",
      suppress: false,
      user_id: "1469282305648751275",
      version: 0,
      viewer_stream_keys: [],
    }
  ],
}
```

also here is the `member` object which has no `guild_id`:
```js
{
    accent_color: null,
    avatar: null,
    banner: null,
    communication_disabled_until: null,
    deaf: false,
    joined_at: "2026-02-06T10:44:28.396Z",
    mute: false,
    nick: null,
    roles: [ "1477633887362781387", "1477633924515893483", "1477635353695658255" ],
    user: {
      avatar: "047a6a91",
      avatar_color: 10036296,
      discriminator: "9852",
      flags: 0,
      global_name: "Luna",
      id: "1469282305648751275",
      username: "luna",
    },
  }
  ```

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] My code follows the project's style guidelines (run `pnpm run lint`)
- [x] I have run `pnpm run build` successfully
- [x] I have run `pnpm run test` successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved voice connection setup by passing only the needed connection details, which should make reconnects and pending voice joins more reliable.
  * Updated voice state handling to use a more complete, standardized payload shape for better compatibility with voice updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->