### PR TITLE
feat(rest): add request-aware retry policy 1/2

### DIFF
--- a/.changeset/quick-dingos-retry.md
+++ b/.changeset/quick-dingos-retry.md
@@ -1,0 +1,6 @@
+---
+'@fluxerjs/core': minor
+'@fluxerjs/rest': minor
+---
+
+Add a request-aware REST retry policy so applications can disable opaque retries for non-idempotent operations without bypassing high-level SDK methods.

--- a/apps/docs/content/guides/errors.mdx
+++ b/apps/docs/content/guides/errors.mdx
@@ -26,6 +26,28 @@ try {
 
 `FluxerError` often wraps a REST failure in `cause`. HTTP status may live on `err.statusCode` or `err.cause?.statusCode` depending on the path.
 
+## Control automatic retries
+
+REST requests retry up to three times by default. For non-idempotent or durably orchestrated mutations, use a request-aware policy to disable automatic retries while retaining them for reads:
+
+```javascript
+import { Client } from '@fluxerjs/core';
+
+const client = new Client({
+  rest: {
+    retries: 3,
+    retryPolicy: ({ method, defaultRetries }) =>
+      method === 'GET' ? defaultRetries : 0,
+  },
+});
+```
+
+The policy runs once per logical request and returns its retry budget. Return `undefined` to retain the configured default. It receives the request method, a sanitized `routeKey` for matching, and the default retry count. The exact caller-supplied route is not included as a separate field: Snowflake IDs are replaced by `:id`, webhook credentials are replaced by `:token`, query parameters are omitted, and absolute URLs are reduced to their origin plus `/:external`. Request bodies and headers are never exposed. Both configured and policy-selected retry counts must be non-negative safe integers.
+
+Treat `routeKey` as matching metadata rather than a logging field when using custom relative routes, whose application-specific path segments cannot be classified by the SDK.
+
+Disabling automatic retries does not make an ambiguous mutation safe to replay. A timeout or transport failure can occur after the server applied the request, so durable applications should persist an unknown outcome and reconcile it explicitly.
+
 ## Common codes
 
 Exact members live on `ErrorCodes`. Ones you will hit early:

--- a/packages/fluxer-core/src/client/Client.multi-instance.test.ts
+++ b/packages/fluxer-core/src/client/Client.multi-instance.test.ts
@@ -57,6 +57,14 @@ describe('multi-instance Client runtimes', () => {
     expect(client.instance.endpoints.media).toBe(DEFAULT_INSTANCE_ENDPOINTS.media);
   });
 
+  it('accepts a request-aware REST retry policy', () => {
+    const retryPolicy = ({ method, defaultRetries }: { method: string; defaultRetries: number }) =>
+      method === 'GET' ? defaultRetries : 0;
+    const client = new Client({ rest: { retries: 3, retryPolicy } });
+
+    expect(client.options.rest?.retryPolicy).toBe(retryPolicy);
+  });
+
   it('applies explicit instance endpoint overrides', () => {
     const client = new Client({
       instance: {

--- a/packages/rest/src/REST.test.ts
+++ b/packages/rest/src/REST.test.ts
@@ -63,6 +63,23 @@ describe('REST', () => {
     );
   });
 
+  it('passes the request retry policy to the request manager', async () => {
+    const retryPolicy = vi.fn(() => 0);
+    const rest = new REST({ retries: 3, retryPolicy });
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      text: () => Promise.resolve('unavailable'),
+      headers: new Headers(),
+    } as unknown as Response);
+
+    await expect(rest.post('/channels/1/messages', { body: { content: 'hello' } })).rejects.toThrow(
+      'HTTP 503',
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(retryPolicy).toHaveBeenCalledOnce();
+  });
+
   it('Routes is exposed', () => {
     expect(REST.Routes).toBe(Routes);
   });

--- a/packages/rest/src/REST.ts
+++ b/packages/rest/src/REST.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events';
 import { Routes } from '@fluxerjs/types';
-import { RequestManager, type RequestOptions } from './RequestManager.js';
+import { RequestManager, type RequestOptions, type RetryPolicy } from './RequestManager.js';
 import {
   DEFAULT_API,
   DEFAULT_USER_AGENT,
@@ -15,6 +15,8 @@ export interface RESTOptions {
   authPrefix?: 'Bot' | 'Bearer';
   timeout?: number;
   retries?: number;
+  /** Select the retry budget for each logical request. */
+  retryPolicy?: RetryPolicy;
   userAgent?: string;
 }
 
@@ -31,6 +33,7 @@ export class REST extends EventEmitter {
       authPrefix: options.authPrefix ?? 'Bot',
       timeout: options.timeout ?? REQUEST_TIMEOUT,
       retries: options.retries ?? MAX_RETRIES,
+      ...(options.retryPolicy ? { retryPolicy: options.retryPolicy } : {}),
       userAgent: options.userAgent ?? DEFAULT_USER_AGENT,
     });
   }

--- a/packages/rest/src/RequestManager.test.ts
+++ b/packages/rest/src/RequestManager.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { RequestManager } from './RequestManager.js';
-import { HTTPError, FluxerAPIError, RateLimitError } from './errors/index.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { FluxerAPIError, HTTPError, RateLimitError } from './errors/index.js';
 import { sharedFetch } from './fetch/sharedFetch.js';
+import { RequestManager } from './RequestManager.js';
 
 vi.mock('./fetch/sharedFetch.js', () => ({
   sharedFetch: vi.fn(),
@@ -119,6 +119,181 @@ describe('RequestManager', () => {
       jsonResponse({ code: 'RATE_LIMITED', message: 'slow down', retry_after: 1 }, { status: 429 }),
     );
     await expect(rm.request('GET', '/channels/1')).rejects.toThrow(RateLimitError);
+  });
+
+  it('uses a request retry policy without changing the configured default', async () => {
+    const retryPolicy = vi.fn(
+      ({ method, defaultRetries }: { method: string; defaultRetries: number }) =>
+        method === 'POST' ? 0 : defaultRetries,
+    );
+    const rm = new RequestManager({ retries: 1, retryPolicy });
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ code: 'RATE_LIMITED', message: 'slow down', retry_after: 0 }, { status: 429 }),
+    );
+
+    await expect(rm.request('POST', '/channels/123456789012345678/messages')).rejects.toThrow(
+      RateLimitError,
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(retryPolicy).toHaveBeenCalledOnce();
+    expect(retryPolicy).toHaveBeenCalledWith({
+      method: 'POST',
+      routeKey: '/channels/:id/messages',
+      defaultRetries: 1,
+    });
+  });
+
+  it('redacts credential-bearing route data from the retry policy context', async () => {
+    const retryPolicy = vi.fn(() => 0);
+    const rm = new RequestManager({ retryPolicy });
+    fetchMock.mockResolvedValue(jsonResponse({ ok: true }));
+    const webhookToken = 'validation-only-secret-token';
+
+    await rm.request(
+      'POST',
+      `/webhooks/123456789012345678/${webhookToken}/messages/987654321098765432`,
+    );
+    expect(retryPolicy).toHaveBeenLastCalledWith({
+      method: 'POST',
+      routeKey: '/webhooks/:id/:token/messages/:id',
+      defaultRetries: 3,
+    });
+    expect(JSON.stringify(retryPolicy.mock.lastCall)).not.toContain(webhookToken);
+
+    await rm.request(
+      'GET',
+      '/users/123456789012345678/profile?guild_id=987654321098765432&token=query-secret',
+    );
+    expect(retryPolicy).toHaveBeenLastCalledWith({
+      method: 'GET',
+      routeKey: '/users/:id/profile',
+      defaultRetries: 3,
+    });
+    expect(JSON.stringify(retryPolicy.mock.lastCall)).not.toContain('query-secret');
+
+    await rm.request(
+      'GET',
+      'https://user:password@cdn.example.com/private/path?signature=external-secret',
+    );
+    expect(retryPolicy).toHaveBeenLastCalledWith({
+      method: 'GET',
+      routeKey: 'https://cdn.example.com/:external',
+      defaultRetries: 3,
+    });
+    expect(JSON.stringify(retryPolicy.mock.lastCall)).not.toMatch(
+      /password|private|external-secret/,
+    );
+  });
+
+  it('falls back to the configured default when the retry policy returns undefined', async () => {
+    const retryPolicy = vi.fn(() => undefined);
+    const rm = new RequestManager({ retries: 1, retryPolicy });
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse(
+          { code: 'RATE_LIMITED', message: 'slow down', retry_after: 0 },
+          { status: 429 },
+        ),
+      )
+      .mockResolvedValueOnce(jsonResponse({ id: '1' }));
+
+    await expect(rm.request('GET', '/channels/1')).resolves.toEqual({ id: '1' });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(retryPolicy).toHaveBeenCalledOnce();
+  });
+
+  it('can suppress retries for retryable server errors', async () => {
+    const rm = new RequestManager({ retries: 3, retryPolicy: () => 0 });
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      text: () => Promise.resolve('unavailable'),
+      headers: new Headers(),
+    } as unknown as Response);
+
+    await expect(rm.request('POST', '/channels/1/messages')).rejects.toThrow(HTTPError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('can suppress retries for transport failures', async () => {
+    const rm = new RequestManager({ retries: 3, retryPolicy: () => 0 });
+    fetchMock.mockRejectedValueOnce(new TypeError('fetch failed'));
+
+    await expect(rm.request('POST', '/channels/1/messages')).rejects.toThrow('fetch failed');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('can suppress retries after a client timeout', async () => {
+    vi.useFakeTimers();
+    try {
+      const rm = new RequestManager({ timeout: 10, retries: 3, retryPolicy: () => 0 });
+      fetchMock.mockImplementationOnce(
+        (_url, init) =>
+          new Promise((_resolve, reject) => {
+            const signal = init?.signal as AbortSignal;
+            signal.addEventListener(
+              'abort',
+              () => reject(Object.assign(new Error('Aborted'), { name: 'AbortError' })),
+              { once: true },
+            );
+          }),
+      );
+
+      const rejection = expect(rm.request('POST', '/channels/1/messages')).rejects.toMatchObject({
+        name: 'AbortError',
+      });
+      await vi.advanceTimersByTimeAsync(10);
+      await rejection;
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('selects retry budgets independently by request method', async () => {
+    const rm = new RequestManager({
+      retries: 1,
+      retryPolicy: ({ method, defaultRetries }) => (method === 'POST' ? 0 : defaultRetries),
+    });
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ code: 'RATE_LIMITED', message: 'slow down', retry_after: 0 }, { status: 429 }),
+    );
+    await expect(rm.request('POST', '/channels/1/messages')).rejects.toThrow(RateLimitError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    fetchMock.mockReset();
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse(
+          { code: 'RATE_LIMITED', message: 'slow down', retry_after: 0 },
+          { status: 429 },
+        ),
+      )
+      .mockResolvedValueOnce(jsonResponse({ id: '1' }));
+    await expect(rm.request('GET', '/channels/1')).resolves.toEqual({ id: '1' });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    -1,
+    1.5,
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+  ])('rejects invalid retry policy result %s before dispatch', async (retries) => {
+    const rm = new RequestManager({ retryPolicy: () => retries });
+
+    await expect(rm.request('GET', '/channels/1')).rejects.toThrow(RangeError);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    -1,
+    1.5,
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+  ])('rejects invalid configured retry count %s', (retries) => {
+    expect(() => new RequestManager({ retries })).toThrow(RangeError);
   });
 
   it('builds multipart when files provided without body', async () => {

--- a/packages/rest/src/RequestManager.ts
+++ b/packages/rest/src/RequestManager.ts
@@ -1,8 +1,7 @@
 import type { APIErrorBody, RateLimitErrorBody } from '@fluxerjs/types';
-import { RateLimitManager } from './RateLimitManager.js';
-import { FluxerAPIError, RateLimitError, HTTPError } from './errors/index.js';
-import { buildFormData, type AttachmentPayload } from './utils/files.js';
+import { FluxerAPIError, HTTPError, RateLimitError } from './errors/index.js';
 import { sharedFetch } from './fetch/sharedFetch.js';
+import { RateLimitManager } from './RateLimitManager.js';
 import {
   DEFAULT_API,
   DEFAULT_USER_AGENT,
@@ -10,6 +9,7 @@ import {
   MAX_RETRIES,
   REQUEST_TIMEOUT,
 } from './utils/constants.js';
+import { type AttachmentPayload, buildFormData } from './utils/files.js';
 
 export interface RequestOptions {
   body?: unknown | FormData;
@@ -20,17 +20,35 @@ export interface RequestOptions {
   signal?: AbortSignal;
 }
 
+/** Context used to choose the retry budget for one logical request. */
+export interface RetryPolicyContext {
+  /** HTTP method supplied to the request manager. */
+  method: string;
+  /** Sanitized route metadata for policy matching. */
+  routeKey: string;
+  /** Validated fallback retry budget from the REST configuration. */
+  defaultRetries: number;
+}
+
+/**
+ * Resolves the retry budget for one logical request.
+ * Return `undefined` to retain the configured default.
+ */
+export type RetryPolicy = (context: RetryPolicyContext) => number | undefined;
+
 export interface RestOptions {
   api: string;
   version: string;
   authPrefix: 'Bot' | 'Bearer';
   timeout: number;
   retries: number;
+  retryPolicy?: RetryPolicy;
   userAgent: string;
 }
 
 const ROUTE_HASH_CACHE_MAX = 1000;
 const SNOWFLAKE_RE = /\d{17,19}/g;
+const WEBHOOK_TOKEN_RE = /(\/webhooks\/:id\/)[^/]+/;
 
 function abortError(): Error {
   const err = new Error('The operation was aborted');
@@ -105,6 +123,25 @@ function backoffMs(attempt: number): number {
   return 500 * (attempt + 1);
 }
 
+function validateRetryCount(value: number, source: string): number {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new RangeError(`${source} must be a non-negative safe integer`);
+  }
+  return value;
+}
+
+function getRetryPolicyRouteKey(route: string, routeHash: string): string {
+  if (route.startsWith('http')) {
+    try {
+      return `${new URL(route).origin}/:external`;
+    } catch {
+      return ':external';
+    }
+  }
+
+  return routeHash.replace(/[?#].*$/, '').replace(WEBHOOK_TOKEN_RE, '$1:token');
+}
+
 /** Flatten Error.cause chain so "fetch failed" surfaces the real undici/network reason. */
 function formatErrorChain(err: Error, maxDepth = 4): string {
   const parts: string[] = [];
@@ -123,12 +160,14 @@ export class RequestManager {
   private readonly routeHashCache = new Map<string, string>();
 
   constructor(options: Partial<RestOptions>) {
+    const retries = validateRetryCount(options.retries ?? MAX_RETRIES, 'retries');
     this.options = {
       api: options.api ?? DEFAULT_API,
       version: options.version ?? DEFAULT_VERSION,
       authPrefix: options.authPrefix ?? 'Bot',
       timeout: options.timeout ?? REQUEST_TIMEOUT,
-      retries: options.retries ?? MAX_RETRIES,
+      retries,
+      ...(options.retryPolicy ? { retryPolicy: options.retryPolicy } : {}),
       userAgent: options.userAgent ?? DEFAULT_USER_AGENT,
     };
   }
@@ -228,13 +267,14 @@ export class RequestManager {
 
   async request<T>(method: string, route: string, options: RequestOptions = {}): Promise<T> {
     const routeHash = this.getRouteHash(route);
+    const retries = this.resolveRetries(method, getRetryPolicyRouteKey(route, routeHash));
     const url = route.startsWith('http') ? route : `${this.baseUrl}${route}`;
     const body = this.buildBody(options);
     const headers = this.buildHeaders(options, body);
     const userSignal = options.signal;
     let lastError: Error | null = null;
 
-    for (let attempt = 0; attempt <= this.options.retries; attempt++) {
+    for (let attempt = 0; attempt <= retries; attempt++) {
       if (userSignal?.aborted) throw abortError();
 
       const wait = this.rateLimiter.getWaitTime(routeHash);
@@ -280,7 +320,7 @@ export class RequestManager {
             response.status,
             { method, path: route },
           );
-          if (attempt < this.options.retries) {
+          if (attempt < retries) {
             lastError = err;
             await sleep(retryMs, userSignal);
             continue;
@@ -290,7 +330,7 @@ export class RequestManager {
 
         if (!response.ok) {
           const err = await this.parseError(response, method, route);
-          if (err.isRetryable && attempt < this.options.retries) {
+          if (err.isRetryable && attempt < retries) {
             lastError = err;
             await sleep(backoffMs(attempt), userSignal);
             continue;
@@ -302,7 +342,7 @@ export class RequestManager {
       } catch (err) {
         if (isAbortError(err)) {
           if (userSignal?.aborted) throw err;
-          if (timedOut && attempt < this.options.retries) {
+          if (timedOut && attempt < retries) {
             lastError = err instanceof Error ? err : new Error(String(err));
             await sleep(backoffMs(attempt), userSignal);
             continue;
@@ -327,7 +367,7 @@ export class RequestManager {
               ? wrapped
               : new Error(detail, { cause: wrapped });
 
-        if (attempt < this.options.retries) {
+        if (attempt < retries) {
           await sleep(backoffMs(attempt), userSignal);
           continue;
         }
@@ -339,5 +379,16 @@ export class RequestManager {
     }
 
     throw lastError ?? new Error('Request failed');
+  }
+
+  private resolveRetries(method: string, routeKey: string): number {
+    const retries = this.options.retryPolicy?.({
+      method,
+      routeKey,
+      defaultRetries: this.options.retries,
+    });
+
+    if (retries === undefined) return this.options.retries;
+    return validateRetryCount(retries, 'Retry policy result');
   }
 }

--- a/packages/rest/src/index.ts
+++ b/packages/rest/src/index.ts
@@ -1,5 +1,11 @@
 export { REST, type RESTOptions } from './REST.js';
-export { RequestManager, type RequestOptions, type RestOptions } from './RequestManager.js';
+export {
+  RequestManager,
+  type RequestOptions,
+  type RestOptions,
+  type RetryPolicy,
+  type RetryPolicyContext,
+} from './RequestManager.js';
 export { RateLimitManager, type RateLimitState } from './RateLimitManager.js';
 export { FluxerAPIError, RateLimitError, HTTPError } from './errors/index.js';
 export { buildFormData, type AttachmentPayload, type AttachmentData } from './utils/files.js';

--- a/packages/rest/src/subpath-request-manager.ts
+++ b/packages/rest/src/subpath-request-manager.ts
@@ -1,1 +1,7 @@
-export { RequestManager, type RequestOptions, type RestOptions } from './RequestManager.js';
+export {
+  RequestManager,
+  type RequestOptions,
+  type RestOptions,
+  type RetryPolicy,
+  type RetryPolicyContext,
+} from './RequestManager.js';


### PR DESCRIPTION
> [!TIP]
> **Stack 1 of 2.** Follow-up: [#41](https://github.com/fluxerjs/core/pull/41). This PR is independently usable and should merge first.

## Description

### 1. At a glance

`main` has one retry count for every REST request. This PR adds an optional `retryPolicy` so an application can keep automatic retries for reads while limiting requests that could repeat a side effect.

For valid existing retry configurations, request behavior is unchanged unless the policy is configured. Invalid configured retry counts now fail during REST construction.

| Policy result | What happens |
| --- | --- |
| `0` | Make the initial transport attempt and do not retry |
| A positive integer | Retry up to that many times after the initial attempt |
| `undefined` | Use the configured default |
| Any other value | Fail before network dispatch |

A common setup is to retain retries for reads and make only one attempt for writes:

```js
const client = new Client({
  rest: {
    retries: 3,
    retryPolicy: ({ method, defaultRetries }) =>
      method === 'GET' ? defaultRetries : 0,
  },
});
```

### 2. From problem to design

#### What was identified on `main`

`RequestManager` applies `options.retries` to every request and every retryable failure path. A caller using high-level SDK methods cannot change that decision for one request.

That matters for mutations. If the server completes a request but its response is lost, a timeout or transport failure is ambiguous: Retrying may repeat the mutation. Disabling retries globally avoids that risk but also removes useful recovery from safe reads and other recoverable requests.

#### Why this is a PR

The retry decision belongs in the shared REST layer because that layer owns rate limits, server-error retries, timeouts, and transport retries. Handling the problem outside it would require bypassing high-level SDK methods or duplicating request behavior in application code.

The policy is configuration-driven rather than a new option on every REST method. That keeps existing call sites unchanged and gives one place to express application retry rules.

#### Why these decisions were made

- **Optional and backward-compatible:** No policy means the existing configured retry count is used.
- **Resolved once per logical request:** The retry budget cannot change midway through an attempt sequence.
- **Separate internal and policy keys:** The rate-limit hash remains unchanged, while the callback receives a purpose-built `routeKey` for policy matching.
- **No raw route field in the callback:** The exact caller-supplied route is not included separately. Built-in webhook credentials are redacted, query parameters are omitted, and absolute URLs are reduced to their origin plus `/:external`.
- **Custom-route boundary:** Application-defined relative path segments cannot be classified by the SDK, so `routeKey` is matching metadata rather than a logging field.
- **`undefined` means fallback:** A policy can override only the requests it cares about.
- **One validation rule:** Configured and policy-selected retry counts must both be non-negative safe integers.
- **The method remains a string:** Narrowing the existing public `RequestManager.request()` method would be a separate breaking API change.

### 3. Technical details

The public policy context is:

```ts
interface RetryPolicyContext {
  method: string;
  routeKey: string;
  defaultRetries: number;
}

type RetryPolicy = (context: RetryPolicyContext) => number | undefined;
```

The policy-facing `routeKey` is sanitized before the callback runs: Snowflake IDs become `:id`, built-in webhook tokens become `:token`, query parameters are removed, and absolute URLs become their origin plus `/:external`. The exact caller-supplied route is not included as a separate field.

The internal rate-limit hash remains separate and unchanged. Policy redaction therefore cannot merge rate-limit buckets that may need distinct webhook identities.

The policy runs after route metadata is derived but before URL, body, header, or network work. Its result controls the same loop for:

- `429` rate-limit responses;
- Retryable HTTP errors;
- Client timeouts;
- Transport failures.

`retries` remains a retry count, not an attempt count. A retry budget of `n` permits at most `n + 1` transport attempts.

```mermaid
flowchart LR
    A["REST request"] --> B["Build request context"]
    B --> C{"retryPolicy configured?"}

    C -- "No" --> D["Use configured default retries"]
    C -- "Yes" --> E["Call policy once with<br/>method, sanitized route, and defaultRetries"]

    E --> F{"Policy result"}
    F -- "undefined" --> D
    F -- "Invalid" --> G["Fail before network dispatch"]
    F -- "Non-negative safe integer" --> H["Use returned retry budget"]

    D --> I["Request loop"]
    H --> I

    I --> J["Handle retryable 429, 5xx,<br/>timeout, and transport failures"]
```

`RetryPolicy` and `RetryPolicyContext` are exported from both the main REST entry point and the request-manager subpath. The client REST configuration passes the policy through unchanged.

#### Validation

- `pnpm run lint` exits successfully; existing repository warnings and informational diagnostics remain.
- `pnpm run build` passes, including declaration and documentation builds.
- `pnpm run test:all` passes.
- Focused request-manager, REST, and client configuration suites pass.
- Regression coverage verifies that webhook tokens, query data, and external URL paths are absent from the policy context.
- ESM, CommonJS, package export, and smoke checks pass.

No live external mutation was performed. Failure-path and metadata-sanitization behavior is covered through request-manager and package-level tests.

The standalone root `pnpm run typecheck` still encounters the existing `packages/types/src/rest/routes.test.ts` Node type/CommonJS configuration issue. Package declaration builds pass.

#### Implementation note

I used OpenAI Codex as an implementation and review aid. I reviewed the API, behavior, tests, and final diff and remain responsible for this submission.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist

- [x] My code follows the project's style guidelines (run `pnpm run lint`)
- [x] I have run `pnpm run build` successfully
- [x] I have run `pnpm run test` successfully
