### PR TITLE
fix(core): handle temporary guild unavailability 2/2

### DIFF
--- a/.changeset/calm-guilds-return.md
+++ b/.changeset/calm-guilds-return.md
@@ -1,0 +1,5 @@
+---
+'@fluxerjs/core': minor
+---
+
+Distinguish temporary guild outages from permanent removal with `GuildUnavailable` and `GuildAvailable` events while preserving the cached guild across recovery.

--- a/apps/docs/content/guides/events.mdx
+++ b/apps/docs/content/guides/events.mdx
@@ -68,6 +68,8 @@ client.on(Events.MessageReactionAdd, (payload) => {});
 client.on(Events.MessageReactionRemove, (payload) => {});
 
 client.on(Events.GuildCreate, (guild) => {});
+client.on(Events.GuildUnavailable, (guild) => {});
+client.on(Events.GuildAvailable, (guild) => {});
 client.on(Events.GuildUpdate, (oldGuild, newGuild) => {});
 client.on(Events.GuildDelete, (guild) => {});
 
@@ -97,6 +99,8 @@ client.on(Events.UserUpdate, (user) => {});
 client.on(Events.VoiceStateUpdate, (data) => {});
 client.on(Events.VoiceServerUpdate, (data) => {});
 ```
+
+`GuildUnavailable` means the gateway temporarily lost access to a guild. The guild remains in `client.guilds` with `guild.available === false`, and repeated unavailable dispatches do not re-emit the event. When it returns, the same `Guild` instance is refreshed, `available` becomes `true`, and `GuildAvailable` fires. `GuildDelete` is reserved for permanent removal.
 
 ## Reaction Events
 
@@ -152,7 +156,7 @@ Events exposed on `Client` via `Events` / `ClientEvents`. Only these names are s
 | Connection | `Ready`, `Resumed`, `Error`, `Debug` |
 | Messages | `MessageCreate`, `MessageUpdate`, `MessageDelete`, `MessageDeleteBulk` |
 | Reactions | `MessageReactionAdd`, `MessageReactionAddMany`, `MessageReactionRemove`, `MessageReactionRemoveAll`, `MessageReactionRemoveEmoji` |
-| Guild | `GuildCreate`, `GuildUpdate`, `GuildDelete`, `GuildCountsUpdate`, `GuildEmojisUpdate`, `GuildStickersUpdate`, `GuildAuditLogEntryCreate` |
+| Guild | `GuildCreate`, `GuildAvailable`, `GuildUnavailable`, `GuildUpdate`, `GuildDelete`, `GuildCountsUpdate`, `GuildEmojisUpdate`, `GuildStickersUpdate`, `GuildAuditLogEntryCreate` |
 | Members | `GuildMemberAdd`, `GuildMemberUpdate`, `GuildMemberRemove`, `GuildMembersChunk` |
 | Roles | `GuildRoleCreate`, `GuildRoleUpdate`, `GuildRoleDelete` |
 | Moderation | `GuildBanAdd`, `GuildBanRemove` |
@@ -182,6 +186,8 @@ Handler argument types from `ClientEvents`. Structure names are classes from `@f
 | `MessageReactionRemoveAll` | `MessageReactionRemoveAllPayload` |
 | `MessageReactionRemoveEmoji` | `MessageReactionRemoveEmojiPayload` |
 | `GuildCreate` | `Guild` |
+| `GuildAvailable` | `Guild` |
+| `GuildUnavailable` | `Guild` |
 | `GuildUpdate` | `Guild`, `Guild` |
 | `GuildDelete` | `Guild` |
 | `GuildMemberAdd` | `GuildMember` |

--- a/packages/fluxer-core/src/client/Client.event-types.typecheck.test.ts
+++ b/packages/fluxer-core/src/client/Client.event-types.typecheck.test.ts
@@ -1,4 +1,5 @@
 import { describe, it } from 'vitest';
+import type { Guild } from '../structures/Guild.js';
 import type { Message } from '../structures/Message.js';
 import type { GuildMembersChunkPayload } from './eventPayloads.js';
 import { Client } from './Client.js';
@@ -22,6 +23,17 @@ describe('Client event typings (compile-time)', () => {
       type _notAny = Assert<IsAny<typeof chunk> extends false ? true : false>;
       type _exact = Assert<IsExactly<typeof chunk, GuildMembersChunkPayload>>;
       const _guildId: string = chunk.guildId;
+    });
+
+    client.on(Events.GuildUnavailable, (guild) => {
+      type _notAny = Assert<IsAny<typeof guild> extends false ? true : false>;
+      type _exact = Assert<IsExactly<typeof guild, Guild>>;
+      const _available: boolean = guild.available;
+    });
+
+    client.on(Events.GuildAvailable, (guild) => {
+      type _exact = Assert<IsExactly<typeof guild, Guild>>;
+      const _guildId: string = guild.id;
     });
 
     client.emit(Events.MessageDeleteBulk, { ids: ['1', '2'], channelId: '3', guildId: null });

--- a/packages/fluxer-core/src/client/ClientEvents.ts
+++ b/packages/fluxer-core/src/client/ClientEvents.ts
@@ -81,6 +81,10 @@ export interface ClientEvents {
 
   [Events.GuildCreate]: [guild: Guild];
 
+  [Events.GuildAvailable]: [guild: Guild];
+
+  [Events.GuildUnavailable]: [guild: Guild];
+
   [Events.GuildUpdate]: [oldGuild: Guild, newGuild: Guild];
 
   [Events.GuildDelete]: [guild: Guild];

--- a/packages/fluxer-core/src/client/GatewayDispatch.ts
+++ b/packages/fluxer-core/src/client/GatewayDispatch.ts
@@ -1,7 +1,7 @@
 import type { GatewayReceivePayload } from '@fluxerjs/types';
 import { Events } from '../util/Events.js';
-import { eventHandlers } from './eventHandlers/index.js';
 import type { Client } from './Client.js';
+import { eventHandlers } from './eventHandlers/index.js';
 
 export function emitClientError(client: Client, err: unknown): void {
   client.emit(Events.Error, err instanceof Error ? err : new Error(String(err)));
@@ -9,7 +9,8 @@ export function emitClientError(client: Client, err: unknown): void {
 
 /**
  * While {@link ClientOptions.waitForGuilds} delays Ready, defer user-facing dispatch handling until Ready fires.
- * GUILD_CREATE must still run immediately so guild cache and {@link Client._onGuildReceived} can finish the handshake.
+ * GUILD_CREATE and a GUILD_DELETE for a pending guild must still run immediately so guild cache and
+ * {@link Client._onGuildReceived} can finish the handshake.
  */
 export function shouldDeferGatewayDispatchUntilReady(
   client: Client,
@@ -17,7 +18,12 @@ export function shouldDeferGatewayDispatchUntilReady(
 ): boolean {
   if (client.options.waitForGuilds !== true || client.readyAt !== null) return false;
   if (payload.op !== 0 || !payload.t) return false;
-  return payload.t !== 'GUILD_CREATE';
+  if (payload.t === 'GUILD_CREATE') return false;
+  if (payload.t === 'GUILD_DELETE') {
+    const data = payload.d as { id?: unknown } | null;
+    if (typeof data?.id === 'string' && client._pendingGuildIds?.has(data.id)) return false;
+  }
+  return true;
 }
 
 /**

--- a/packages/fluxer-core/src/client/eventHandlers/guilds.test.ts
+++ b/packages/fluxer-core/src/client/eventHandlers/guilds.test.ts
@@ -1,0 +1,239 @@
+import type { APIMessage } from '@fluxerjs/types';
+import { describe, expect, it, vi } from 'vitest';
+import { Guild } from '../../structures/Guild.js';
+import { Events } from '../../util/Events.js';
+import { Client } from '../Client.js';
+import { shouldDeferGatewayDispatchUntilReady } from '../GatewayDispatch.js';
+import { guildHandlers } from './guilds.js';
+
+function guildPayload(name: string) {
+  return {
+    id: 'g1',
+    name,
+    icon: null,
+    banner: null,
+    splash: null,
+    owner_id: 'owner1',
+    features: [],
+    afk_timeout: 0,
+    nsfw_level: 0,
+    verification_level: 0,
+    mfa_level: 0,
+    explicit_content_filter: 0,
+    default_message_notifications: 0,
+  };
+}
+
+function role(id: string) {
+  return {
+    id,
+    name: id,
+    color: 0,
+    position: 0,
+    permissions: '0',
+    hoist: false,
+    mentionable: false,
+  };
+}
+
+function channel(id: string) {
+  return { id, guild_id: 'g1', type: 0, name: id };
+}
+
+function member(id: string) {
+  return {
+    user: { id, username: id, discriminator: '0' },
+    roles: [],
+    joined_at: new Date(0).toISOString(),
+  };
+}
+
+function message(id: string, channelId: string): APIMessage {
+  return {
+    id,
+    channel_id: channelId,
+    author: { id: 'author1', username: 'author', discriminator: '0' },
+    type: 0,
+    flags: 0,
+    content: '',
+    timestamp: new Date(0).toISOString(),
+    edited_timestamp: null,
+    pinned: false,
+  };
+}
+
+async function dispatch(client: Client, event: 'GUILD_CREATE' | 'GUILD_DELETE', data: unknown) {
+  await guildHandlers[event](client, data);
+}
+
+describe('guild availability lifecycle', () => {
+  it('retains a temporarily unavailable guild and emits GuildUnavailable', async () => {
+    const client = new Client({ gatewayDeferHandlers: false });
+    const guild = new Guild(client, guildPayload('Before outage'));
+    client.guilds.set(guild.id, guild);
+    const emit = vi.spyOn(client, 'emit');
+
+    await dispatch(client, 'GUILD_DELETE', { id: guild.id, unavailable: true });
+
+    expect(client.guilds.get(guild.id)).toBe(guild);
+    expect(guild.available).toBe(false);
+    expect(emit).toHaveBeenCalledWith(Events.GuildUnavailable, guild);
+    expect(emit.mock.calls.some(([event]) => event === Events.GuildDelete)).toBe(false);
+  });
+
+  it('restores the same guild instance from the next available GUILD_CREATE snapshot', async () => {
+    const client = new Client({ gatewayDeferHandlers: false });
+    const emit = vi.spyOn(client, 'emit');
+
+    await dispatch(client, 'GUILD_CREATE', {
+      ...guildPayload('Before outage'),
+      roles: [role('old-role')],
+      channels: [channel('old-channel')],
+      members: [member('old-member')],
+    });
+    const guild = client.guilds.get('g1');
+    expect(guild).toBeDefined();
+
+    await dispatch(client, 'GUILD_DELETE', { id: 'g1', unavailable: true });
+    emit.mockClear();
+    await dispatch(client, 'GUILD_CREATE', {
+      ...guildPayload('After outage'),
+      roles: [role('new-role')],
+      channels: [channel('new-channel')],
+      members: [member('new-member')],
+    });
+
+    expect(client.guilds.get('g1')).toBe(guild);
+    expect(guild?.available).toBe(true);
+    expect(guild?.name).toBe('After outage');
+    expect(guild?.roles.has('old-role')).toBe(false);
+    expect(guild?.roles.has('new-role')).toBe(true);
+    expect(guild?.channels.has('old-channel')).toBe(false);
+    expect(client.channels.has('old-channel')).toBe(false);
+    expect(guild?.channels.has('new-channel')).toBe(true);
+    expect(client.channels.has('new-channel')).toBe(true);
+    // Recovery member snapshots are partial, so previously cached members remain.
+    expect(guild?.members.has('old-member')).toBe(true);
+    expect(guild?.members.has('new-member')).toBe(true);
+    expect(emit).toHaveBeenCalledWith(Events.GuildAvailable, guild);
+    expect(emit.mock.calls.some(([event]) => event === Events.GuildCreate)).toBe(false);
+  });
+
+  it('keeps permanent GUILD_DELETE behavior after an outage', async () => {
+    const client = new Client({ gatewayDeferHandlers: false });
+    const guild = new Guild(client, guildPayload('Removed guild'));
+    guild.available = false;
+    client.guilds.set(guild.id, guild);
+    const emit = vi.spyOn(client, 'emit');
+
+    await dispatch(client, 'GUILD_DELETE', { id: guild.id });
+
+    expect(client.guilds.has(guild.id)).toBe(false);
+    expect(emit).toHaveBeenCalledWith(Events.GuildDelete, guild);
+    expect(emit.mock.calls.some(([event]) => event === Events.GuildUnavailable)).toBe(false);
+  });
+
+  it('emits GuildUnavailable only when availability changes', async () => {
+    const client = new Client({ gatewayDeferHandlers: false });
+    const guild = new Guild(client, guildPayload('Outage guild'));
+    client.guilds.set(guild.id, guild);
+    const emit = vi.spyOn(client, 'emit');
+
+    await dispatch(client, 'GUILD_DELETE', { id: guild.id, unavailable: true });
+    await dispatch(client, 'GUILD_CREATE', { id: guild.id, unavailable: true });
+
+    expect(emit.mock.calls.filter(([event]) => event === Events.GuildUnavailable)).toHaveLength(1);
+  });
+
+  it('keeps a recovered guild unavailable when cache rebuilding fails', async () => {
+    const client = new Client({ gatewayDeferHandlers: false });
+    const guild = new Guild(client, guildPayload('Recovering guild'));
+    guild.available = false;
+    client.guilds.set(guild.id, guild);
+    const setChannel = vi.spyOn(client.channels, 'set').mockImplementationOnce(() => {
+      throw new Error('cache write failed');
+    });
+
+    try {
+      await expect(
+        dispatch(client, 'GUILD_CREATE', {
+          ...guildPayload('Recovered guild'),
+          channels: [channel('new-channel')],
+        }),
+      ).rejects.toThrow('cache write failed');
+      expect(guild.available).toBe(false);
+    } finally {
+      setChannel.mockRestore();
+    }
+  });
+
+  it('clears message caches only for channels absent from the recovery snapshot', async () => {
+    const client = new Client({ gatewayDeferHandlers: false, cache: { messages: 10 } });
+    await dispatch(client, 'GUILD_CREATE', {
+      ...guildPayload('Before outage'),
+      channels: [channel('retained-channel'), channel('removed-channel')],
+    });
+    client._addMessageToCache('retained-channel', message('retained-message', 'retained-channel'));
+    client._addMessageToCache('removed-channel', message('removed-message', 'removed-channel'));
+
+    await dispatch(client, 'GUILD_DELETE', { id: 'g1', unavailable: true });
+    await dispatch(client, 'GUILD_CREATE', {
+      ...guildPayload('After outage'),
+      channels: [channel('retained-channel')],
+    });
+
+    expect(client._getMessageCache('retained-channel')?.has('retained-message')).toBe(true);
+    expect(client._getMessageCache('removed-channel')?.has('removed-message')).toBe(false);
+  });
+
+  it.each([
+    'GUILD_CREATE',
+    'GUILD_DELETE',
+  ] as const)('settles a pending startup guild on unavailable %s', async (event) => {
+    const client = new Client({ waitForGuilds: true, gatewayDeferHandlers: false });
+    client._pendingGuildIds = new Set(['g1']);
+    const emit = vi.spyOn(client, 'emit');
+
+    await (
+      client as unknown as { handleDispatch: (payload: unknown) => Promise<void> }
+    ).handleDispatch({ op: 0, t: event, d: { id: 'g1', unavailable: true } });
+
+    expect(client._pendingGuildIds).toBeNull();
+    expect(client.readyAt).toBeInstanceOf(Date);
+    expect(client.guilds.has('g1')).toBe(false);
+    expect(emit).toHaveBeenCalledWith(Events.Ready);
+  });
+
+  it('runs only pending guild deletes before Ready', () => {
+    const client = new Client({ waitForGuilds: true });
+    client._pendingGuildIds = new Set(['g1']);
+
+    expect(
+      shouldDeferGatewayDispatchUntilReady(client, {
+        op: 0,
+        t: 'GUILD_DELETE',
+        s: 1,
+        d: { id: 'g1', unavailable: true },
+      }),
+    ).toBe(false);
+    expect(
+      shouldDeferGatewayDispatchUntilReady(client, {
+        op: 0,
+        t: 'GUILD_DELETE',
+        s: 2,
+        d: { id: 'g2', unavailable: true },
+      }),
+    ).toBe(true);
+  });
+
+  it('ignores unavailable stubs for guilds that are not cached yet', async () => {
+    const client = new Client({ gatewayDeferHandlers: false });
+    const emit = vi.spyOn(client, 'emit');
+
+    await dispatch(client, 'GUILD_CREATE', { id: 'g1', unavailable: true });
+    await dispatch(client, 'GUILD_DELETE', { id: 'g1', unavailable: true });
+
+    expect(client.guilds.has('g1')).toBe(false);
+    expect(emit).not.toHaveBeenCalled();
+  });
+});

--- a/packages/fluxer-core/src/client/eventHandlers/guilds.ts
+++ b/packages/fluxer-core/src/client/eventHandlers/guilds.ts
@@ -2,28 +2,78 @@ import type {
   APIChannel,
   APIGuild,
   APIGuildMember,
+  APIRole,
+  GatewayGuildDeleteDispatchData,
   GatewayVoiceStateUpdateDispatchData,
 } from '@fluxerjs/types';
-import { Events } from '../../util/Events.js';
-import { normalizeGuildPayload } from '../../util/guildUtils.js';
 import { Channel, type GuildChannel } from '../../structures/Channel.js';
 import { Guild } from '../../structures/Guild.js';
+import { Role } from '../../structures/Role.js';
+import { Events } from '../../util/Events.js';
+import { normalizeGuildPayload } from '../../util/guildUtils.js';
+import type { Client } from '../Client.js';
 import { cacheMember } from './helpers.js';
 import type { HandlerMap } from './types.js';
 
+type GuildCreatePayload = APIGuild & {
+  unavailable?: boolean;
+  channels?: APIChannel[];
+  voice_states?: GatewayVoiceStateUpdateDispatchData[];
+  members?: Array<APIGuildMember & { user: { id: string } }>;
+  roles?: APIRole[];
+};
+
+function markGuildUnavailable(client: Client, id: string): void {
+  const guild = client.guilds.get(id);
+  if (!guild || guild.available === false) return;
+  guild.available = false;
+  client.emit(Events.GuildUnavailable, guild);
+}
+
+function refreshRecoveredGuild(guild: Guild, data: GuildCreatePayload): void {
+  guild._patch(data);
+
+  if (data.roles !== undefined) {
+    guild.roles.clear();
+    for (const role of data.roles) {
+      guild.roles.set(role.id, new Role(guild.client, role, guild.id));
+    }
+  }
+
+  if (data.channels !== undefined) {
+    const recoveredChannelIds = new Set(data.channels.map((channel) => channel.id));
+    for (const channel of guild.channels.values()) {
+      guild.client.channels.delete(channel.id);
+      if (!recoveredChannelIds.has(channel.id)) guild.client._clearMessageCache(channel.id);
+    }
+    guild.channels.clear();
+  }
+}
+
 export const guildHandlers: HandlerMap = {
   GUILD_CREATE(client, d) {
+    const raw = d as { id?: unknown; unavailable?: unknown };
+    if (raw.unavailable === true) {
+      if (typeof raw.id === 'string') {
+        try {
+          markGuildUnavailable(client, raw.id);
+        } finally {
+          client._onGuildReceived(raw.id);
+        }
+      }
+      return;
+    }
+
     const guildData = normalizeGuildPayload(d as unknown);
     if (!guildData) return;
 
-    const guild = new Guild(client, guildData);
-    client.guilds.set(guild.id, guild);
+    const g = d as GuildCreatePayload;
+    const existing = client.guilds.get(guildData.id);
+    const recovered = existing?.available === false;
+    const guild = recovered && existing ? existing : new Guild(client, guildData);
 
-    const g = d as APIGuild & {
-      channels?: APIChannel[];
-      voice_states?: GatewayVoiceStateUpdateDispatchData[];
-      members?: Array<APIGuildMember & { user: { id: string } }>;
-    };
+    if (recovered) refreshRecoveredGuild(guild, g);
+    client.guilds.set(guild.id, guild);
 
     for (const ch of g.channels ?? []) {
       const channel = Channel.from(client, ch);
@@ -32,9 +82,11 @@ export const guildHandlers: HandlerMap = {
         guild.channels.set(channel.id, channel as GuildChannel);
       }
     }
+    // GUILD_CREATE member lists may be partial, so merge supplied members into the retained cache.
     for (const m of g.members ?? []) cacheMember(client, guild, m);
 
-    client.emit(Events.GuildCreate, guild);
+    if (recovered) guild.available = true;
+    client.emit(recovered ? Events.GuildAvailable : Events.GuildCreate, guild);
     if (g.voice_states?.length) {
       client.emit(Events.VoiceStatesSync, { guildId: guild.id, voiceStates: g.voice_states });
     }
@@ -59,10 +111,19 @@ export const guildHandlers: HandlerMap = {
   },
 
   GUILD_DELETE(client, d) {
-    const { id } = d as { id: string };
-    const guild = client.guilds.get(id);
-    if (!guild) return;
-    client.guilds.delete(id);
-    client.emit(Events.GuildDelete, guild);
+    const { id, unavailable } = d as GatewayGuildDeleteDispatchData;
+    try {
+      if (unavailable === true) {
+        markGuildUnavailable(client, id);
+        return;
+      }
+
+      const guild = client.guilds.get(id);
+      if (!guild) return;
+      client.guilds.delete(id);
+      client.emit(Events.GuildDelete, guild);
+    } finally {
+      client._onGuildReceived(id);
+    }
   },
 };

--- a/packages/fluxer-core/src/structures/guild/Guild.ts
+++ b/packages/fluxer-core/src/structures/guild/Guild.ts
@@ -51,6 +51,8 @@ export class Guild extends Base {
   readonly client: Client;
   /** Snowflake ID of this guild. */
   readonly id: string;
+  /** Whether the guild is currently available through the gateway. */
+  available = true;
   /** Guild name. */
   name: string;
   /** Icon hash (use {@link iconURL} to get full CDN URL). */

--- a/packages/fluxer-core/src/util/Events.ts
+++ b/packages/fluxer-core/src/util/Events.ts
@@ -11,6 +11,8 @@ export const Events = {
   MessageReactionRemoveAll: 'messageReactionRemoveAll',
   MessageReactionRemoveEmoji: 'messageReactionRemoveEmoji',
   GuildCreate: 'guildCreate',
+  GuildAvailable: 'guildAvailable',
+  GuildUnavailable: 'guildUnavailable',
   GuildUpdate: 'guildUpdate',
   GuildDelete: 'guildDelete',
   GuildBanAdd: 'guildBanAdd',


### PR DESCRIPTION
> [!WARNING]
> **Stack 2 of 2 — depends on [#40](https://github.com/fluxerjs/core/pull/40).**
>
> This commit is directly based on #40, so GitHub shows both commits until the first PR merges. Review the follow-up by itself in the [isolated diff](https://github.com/Neonsy/core/compare/feat/request-retry-policy...fix/guild-delete-unavailable).

## Description

### 1. At a glance

Fluxer can temporarily lose access to a guild without removing the bot from it. On `main`, that temporary outage is handled like a permanent deletion.

This PR separates the two cases:

| Situation | Behavior on `main` | Behavior in this PR |
| --- | --- | --- |
| Guild becomes temporarily unavailable | Remove it and emit `GuildDelete` | Keep it, set `available = false`, and emit `GuildUnavailable` |
| Guild returns | Create a new `Guild` and emit `GuildCreate` | Refresh the retained `Guild`, set `available = true`, and emit `GuildAvailable` |
| Bot is actually removed | Remove it and emit `GuildDelete` | Unchanged |
| Expected startup guild is unavailable | Readiness can remain waiting for it | Settle that guild without creating a partial cache entry |

For consumers, the simple rule is: Temporary outage events preserve the guild; `GuildDelete` means permanent removal.

### 2. From problem to design

#### What was identified on `main`

The `GUILD_DELETE` handler removes a cached guild without checking `unavailable`. The gateway uses `unavailable: true` for a temporary outage, so the cache loses a valid guild and consumers receive the wrong lifecycle signal.

The startup gate also allows `GUILD_CREATE` through before `Ready` but defers `GUILD_DELETE`. If an unavailable guild is still in the pending startup set, that ordering can prevent the event that settles it from running.

A related recovery question was whether the `members` array is a complete snapshot. Fluxer's gateway builds that array from a limited member view, including the current user and relevant voice members, so it is not authoritative and must not replace the entire member cache.

#### Why this is a PR

Temporary unavailability is a distinct gateway state, not a deletion variant that applications should reconstruct themselves. The SDK owns the guild cache and startup handshake, so it must preserve the correct object, expose the state clearly, and emit events that match what happened.

Without this change, applications can lose cached state, see false deletion events, hold references to an obsolete `Guild`, or wait indefinitely for `Ready` in the affected startup path.

#### Why these decisions were made

- **Retain the existing `Guild`:** References held by application code remain valid across an outage.
- **Expose `Guild.available`:** Consumers can inspect the current state without inferring it from cache presence.
- **Use `GuildUnavailable` and `GuildAvailable`:** Outages and recoveries no longer masquerade as leave/join events.
- **Emit on transitions only:** Repeated unavailable notifications do not produce duplicate `GuildUnavailable` events.
- **Replace supplied roles and channels:** Those recovery collections represent the current visible snapshot and should not retain removed entries.
- **Merge supplied members:** The gateway member list is partial, so clearing the existing cache would discard valid members.
- **Mark available last:** A guild is not considered recovered until cache rebuilding succeeds.
- **Open the startup gate narrowly:** Only a `GUILD_DELETE` for an actually pending guild bypasses deferral; unrelated events still wait until after `Ready`.
- **Do not create partial guilds:** Unavailable stubs settle startup state but are not enough to construct a usable `Guild`.
- **Clean only recovery-owned stale messages:** Message caches are cleared for channels missing from the recovered snapshot and retained for channels that still exist.

While reviewing `main`, permanent guild deletion was also found not to cascade through every global channel and message-cache entry. That behavior predates this PR and has broader deletion-ownership implications, so it is intentionally not changed here. This PR only performs cleanup required by recovery.

### 3. Technical details

The public lifecycle is:

```mermaid
flowchart TD
    A[Guild is available in cache] --> B[GUILD_DELETE received]

    B --> C{unavailable = true?}

    C -- Yes --> D[Keep guild in cache<br/>set available = false]
    D --> E[Emit GuildUnavailable]
    E --> F[Later: matching GUILD_CREATE]
    F --> G[Update same guild object<br/>replace roles, channels, members<br/>set available = true]
    G --> H[Emit GuildAvailable]

    C -- No --> I[Remove guild from cache]
    I --> J[Emit GuildDelete]
```

Recovery applies the full payload in this order:

1. Patch guild metadata.
2. Replace roles when roles are supplied.
3. Remove previous channel objects from the global and guild caches.
4. Clear message caches for channel IDs absent from the recovered snapshot.
5. Recreate supplied channels.
6. Merge supplied members into the retained member cache.
7. Set `guild.available = true`.
8. Emit `GuildAvailable` with the retained instance.

If rebuilding throws, `available` remains `false`; the SDK does not expose a partially rebuilt guild as recovered.

For startup readiness:

- Unavailable `GUILD_CREATE` settles its pending ID without creating a partial guild;
- `GUILD_DELETE` bypasses pre-Ready deferral only when its ID is pending;
- Unavailable and permanent deletes both settle a matching pending ID;
- Unrelated gateway dispatches remain deferred until after `Ready`.

The public API addition consists of:

- `Guild.available`;
- `Events.GuildUnavailable` and its typed client event;
- `Events.GuildAvailable` and its typed client event.

Unknown, non-pending unavailable stubs remain ignored. Permanent deletion works from either the available or unavailable state.

#### Validation

- `pnpm run lint` exits successfully; existing repository warnings and informational diagnostics remain.
- `pnpm run build` passes, including declaration and documentation builds.
- `pnpm run test:all` passes.
- The focused guild lifecycle suite passes all 10 tests.
- Tests cover startup settlement for both unavailable dispatch forms, transition-only events, instance reuse, partial member retention, recovery failure, stale channel-message cleanup, and permanent deletion after an outage.
- ESM, CommonJS, package export, and smoke checks pass.

No live gateway outage was reproduced. Lifecycle confidence comes from focused dispatch/cache tests, inspection of the gateway payload construction, and the complete package suite.

The standalone root `pnpm run typecheck` still encounters the existing `packages/types/src/rest/routes.test.ts` Node type/CommonJS configuration issue. Package declaration builds pass.

If #40 is squash-merged and GitHub cannot remove its commit from this PR automatically, this branch will need to be rebased onto the resulting upstream `main` before merge.

#### Implementation note

I used OpenAI Codex as an implementation and review aid. I reviewed the gateway behavior, cache semantics, tests, and final diff and remain responsible for this submission.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist

- [x] My code follows the project's style guidelines (run `pnpm run lint`)
- [x] I have run `pnpm run build` successfully
- [x] I have run `pnpm run test` successfully