### PR TITLE
fix(core): hydrate nested gateway guild properties

### DIFF
--- a/packages/fluxer-core/src/client/Client.gateway.test.ts
+++ b/packages/fluxer-core/src/client/Client.gateway.test.ts
@@ -1,17 +1,66 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { Routes } from '@fluxerjs/types';
 import type { APIUser } from '@fluxerjs/types';
-import { Client } from './Client.js';
-import { Events } from '../util/Events.js';
-import { Invite } from '../structures/Invite.js';
+import { Routes } from '@fluxerjs/types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Guild } from '../structures/Guild.js';
+import { Invite } from '../structures/Invite.js';
+import { Events } from '../util/Events.js';
+import { Client } from './Client.js';
 import { ClientUser } from './ClientUser.js';
+import { hydrateReadyGuilds } from './GatewayReady.js';
 
 describe('Client gateway helpers and dispatch', () => {
   let client: Client;
 
   beforeEach(() => {
     client = new Client();
+  });
+
+  it('hydrates nested READY guild properties before caching', async () => {
+    hydrateReadyGuilds(
+      client,
+      [
+        {
+          id: 'g1',
+          properties: {
+            id: 'g1',
+            name: 'Nested Guild',
+            icon: 'icon-hash',
+            banner: null,
+            splash: 'splash-hash',
+            owner_id: 'owner1',
+            features: ['BANNER'],
+            afk_timeout: 300,
+            nsfw_level: 0,
+            verification_level: 1,
+            mfa_level: 0,
+            explicit_content_filter: 2,
+            default_message_notifications: 1,
+          },
+          channels: [],
+          roles: [],
+          members: [],
+          emojis: [],
+        },
+      ],
+      false,
+    );
+    const get = vi.spyOn(client.rest, 'get');
+
+    const guild = await client.guilds.fetch('g1');
+
+    expect(guild).toMatchObject({
+      id: 'g1',
+      name: 'Nested Guild',
+      icon: 'icon-hash',
+      splash: 'splash-hash',
+      ownerId: 'owner1',
+      features: ['BANNER'],
+      afkTimeout: 300,
+      verificationLevel: 1,
+      explicitContentFilter: 2,
+      defaultMessageNotifications: 1,
+    });
+    expect(get).not.toHaveBeenCalled();
   });
 
   it('fetchGatewayInfo() fetches gateway metadata from /gateway/bot', async () => {

--- a/packages/fluxer-core/src/client/GatewayReady.ts
+++ b/packages/fluxer-core/src/client/GatewayReady.ts
@@ -13,7 +13,7 @@ import { FluxerError } from '../errors/FluxerError.js';
 import { Channel, type GuildChannel } from '../structures/Channel.js';
 import { Guild } from '../structures/Guild.js';
 import { Events } from '../util/Events.js';
-import { type GatewayGuildPayload, normalizeGuildPayload } from '../util/guildUtils';
+import { type GatewayGuildPayload, normalizeGuildSnapshotPayload } from '../util/guildUtils';
 import type { Client } from './Client.js';
 import { ClientUser } from './ClientUser.js';
 import {
@@ -51,7 +51,7 @@ export function hydrateReadyGuilds(
       if (pending !== null && g.id) pending.add(g.id);
       continue;
     }
-    const guildData = normalizeGuildPayload(g as unknown);
+    const guildData = normalizeGuildSnapshotPayload(g as unknown);
     if (!guildData) continue;
     const guild = new Guild(client, guildData);
     client.guilds.set(guild.id, guild);

--- a/packages/fluxer-core/src/client/GatewayReady.ts
+++ b/packages/fluxer-core/src/client/GatewayReady.ts
@@ -1,28 +1,39 @@
-import { WebSocketManager } from '@fluxerjs/ws';
 import type {
   APIChannel,
-  APIGuild,
+  APIEmoji,
+  APIGuildMember,
+  APISticker,
   APIUser,
   GatewayReceivePayload,
   GatewayVoiceStateUpdateDispatchData,
 } from '@fluxerjs/types';
+import { WebSocketManager } from '@fluxerjs/ws';
 import { ErrorCodes } from '../errors/ErrorCodes.js';
 import { FluxerError } from '../errors/FluxerError.js';
-import { Events } from '../util/Events.js';
-import { normalizeGuildPayload } from '../util/guildUtils';
-import { Guild } from '../structures/Guild.js';
 import { Channel, type GuildChannel } from '../structures/Channel.js';
+import { Guild } from '../structures/Guild.js';
+import { Events } from '../util/Events.js';
+import { type GatewayGuildPayload, normalizeGuildPayload } from '../util/guildUtils';
+import type { Client } from './Client.js';
 import { ClientUser } from './ClientUser.js';
 import {
   emitClientError,
   flushDeferredGatewayDispatches,
   handleGatewayDispatch,
 } from './GatewayDispatch.js';
-import type { Client } from './Client.js';
 
 export type ReadyPayload = {
   user: APIUser;
-  guilds: Array<APIGuild & { unavailable?: boolean }>;
+  guilds: ReadyGuildPayload[];
+};
+
+type ReadyGuildPayload = GatewayGuildPayload & {
+  unavailable?: boolean;
+  channels?: APIChannel[];
+  emojis?: APIEmoji[];
+  members?: APIGuildMember[];
+  stickers?: APISticker[];
+  voice_states?: GatewayVoiceStateUpdateDispatchData[];
 };
 
 /** Milliseconds to wait for GUILD_CREATE stream when READY has no guilds. */
@@ -31,7 +42,7 @@ export const GUILD_STREAM_SETTLE_MS = 500;
 /** Hydrate guild and channel caches from the READY payload. Returns pending unavailable guild IDs when waitForGuilds. */
 export function hydrateReadyGuilds(
   client: Client,
-  guilds: Array<APIGuild & { unavailable?: boolean }>,
+  guilds: ReadyGuildPayload[],
   waitForGuilds: boolean,
 ): Set<string> | null {
   const pending = waitForGuilds ? new Set<string>() : null;
@@ -44,21 +55,17 @@ export function hydrateReadyGuilds(
     if (!guildData) continue;
     const guild = new Guild(client, guildData);
     client.guilds.set(guild.id, guild);
-    const withCh = g as APIGuild & {
-      channels?: APIChannel[];
-      voice_states?: GatewayVoiceStateUpdateDispatchData[];
-    };
-    for (const ch of withCh.channels ?? []) {
+    for (const ch of g.channels ?? []) {
       const channel = Channel.from(client, ch);
       if (channel) {
         client.channels.set(channel.id, channel);
         guild.channels.set(channel.id, channel as GuildChannel);
       }
     }
-    if (withCh.voice_states?.length) {
+    if (g.voice_states?.length) {
       client.emit(Events.VoiceStatesSync, {
         guildId: guild.id,
-        voiceStates: withCh.voice_states,
+        voiceStates: g.voice_states,
       });
     }
   }

--- a/packages/fluxer-core/src/client/eventHandlers/guilds.test.ts
+++ b/packages/fluxer-core/src/client/eventHandlers/guilds.test.ts
@@ -62,7 +62,11 @@ function message(id: string, channelId: string): APIMessage {
   };
 }
 
-async function dispatch(client: Client, event: 'GUILD_CREATE' | 'GUILD_DELETE', data: unknown) {
+async function dispatch(
+  client: Client,
+  event: 'GUILD_CREATE' | 'GUILD_UPDATE' | 'GUILD_DELETE',
+  data: unknown,
+) {
   await guildHandlers[event](client, data);
 }
 
@@ -84,6 +88,20 @@ describe('guild availability lifecycle', () => {
       name: 'Nested Guild',
       ownerId: 'owner1',
     });
+  });
+
+  it('treats GUILD_UPDATE as flat when it contains a properties field', async () => {
+    const client = new Client({ gatewayDeferHandlers: false });
+    const guild = new Guild(client, guildPayload('Before update'));
+    client.guilds.set(guild.id, guild);
+
+    await dispatch(client, 'GUILD_UPDATE', {
+      id: 'g1',
+      name: 'Outer update',
+      properties: guildPayload('Nested collision'),
+    });
+
+    expect(guild.name).toBe('Outer update');
   });
 
   it('retains a temporarily unavailable guild and emits GuildUnavailable', async () => {

--- a/packages/fluxer-core/src/client/eventHandlers/guilds.test.ts
+++ b/packages/fluxer-core/src/client/eventHandlers/guilds.test.ts
@@ -67,6 +67,25 @@ async function dispatch(client: Client, event: 'GUILD_CREATE' | 'GUILD_DELETE', 
 }
 
 describe('guild availability lifecycle', () => {
+  it('hydrates nested GUILD_CREATE properties', async () => {
+    const client = new Client({ gatewayDeferHandlers: false });
+
+    await dispatch(client, 'GUILD_CREATE', {
+      id: 'g1',
+      properties: guildPayload('Nested Guild'),
+      roles: [],
+      channels: [],
+      members: [],
+      emojis: [],
+    });
+
+    expect(client.guilds.get('g1')).toMatchObject({
+      id: 'g1',
+      name: 'Nested Guild',
+      ownerId: 'owner1',
+    });
+  });
+
   it('retains a temporarily unavailable guild and emits GuildUnavailable', async () => {
     const client = new Client({ gatewayDeferHandlers: false });
     const guild = new Guild(client, guildPayload('Before outage'));
@@ -97,7 +116,8 @@ describe('guild availability lifecycle', () => {
     await dispatch(client, 'GUILD_DELETE', { id: 'g1', unavailable: true });
     emit.mockClear();
     await dispatch(client, 'GUILD_CREATE', {
-      ...guildPayload('After outage'),
+      id: 'g1',
+      properties: guildPayload('After outage'),
       roles: [role('new-role')],
       channels: [channel('new-channel')],
       members: [member('new-member')],

--- a/packages/fluxer-core/src/client/eventHandlers/guilds.ts
+++ b/packages/fluxer-core/src/client/eventHandlers/guilds.ts
@@ -9,7 +9,11 @@ import { Channel, type GuildChannel } from '../../structures/Channel.js';
 import { Guild } from '../../structures/Guild.js';
 import { Role } from '../../structures/Role.js';
 import { Events } from '../../util/Events.js';
-import { type GatewayGuildPayload, normalizeGuildPayload } from '../../util/guildUtils.js';
+import {
+  type GatewayGuildPayload,
+  normalizeGuildSnapshotPayload,
+  normalizeGuildUpdatePayload,
+} from '../../util/guildUtils.js';
 import type { Client } from '../Client.js';
 import { cacheMember } from './helpers.js';
 import type { HandlerMap } from './types.js';
@@ -61,7 +65,7 @@ export const guildHandlers: HandlerMap = {
       return;
     }
 
-    const guildData = normalizeGuildPayload(d as unknown);
+    const guildData = normalizeGuildSnapshotPayload(d as unknown);
     if (!guildData) return;
 
     const g = d as GuildCreatePayload;
@@ -94,7 +98,7 @@ export const guildHandlers: HandlerMap = {
   },
 
   GUILD_UPDATE(client, d) {
-    const guildData = normalizeGuildPayload(d as unknown);
+    const guildData = normalizeGuildUpdatePayload(d as unknown);
     if (!guildData) return;
 
     const existing = client.guilds.get(guildData.id);

--- a/packages/fluxer-core/src/client/eventHandlers/guilds.ts
+++ b/packages/fluxer-core/src/client/eventHandlers/guilds.ts
@@ -1,6 +1,5 @@
 import type {
   APIChannel,
-  APIGuild,
   APIGuildMember,
   APIRole,
   GatewayGuildDeleteDispatchData,
@@ -10,12 +9,12 @@ import { Channel, type GuildChannel } from '../../structures/Channel.js';
 import { Guild } from '../../structures/Guild.js';
 import { Role } from '../../structures/Role.js';
 import { Events } from '../../util/Events.js';
-import { normalizeGuildPayload } from '../../util/guildUtils.js';
+import { type GatewayGuildPayload, normalizeGuildPayload } from '../../util/guildUtils.js';
 import type { Client } from '../Client.js';
 import { cacheMember } from './helpers.js';
 import type { HandlerMap } from './types.js';
 
-type GuildCreatePayload = APIGuild & {
+type GuildCreatePayload = GatewayGuildPayload & {
   unavailable?: boolean;
   channels?: APIChannel[];
   voice_states?: GatewayVoiceStateUpdateDispatchData[];
@@ -31,8 +30,6 @@ function markGuildUnavailable(client: Client, id: string): void {
 }
 
 function refreshRecoveredGuild(guild: Guild, data: GuildCreatePayload): void {
-  guild._patch(data);
-
   if (data.roles !== undefined) {
     guild.roles.clear();
     for (const role of data.roles) {
@@ -72,7 +69,10 @@ export const guildHandlers: HandlerMap = {
     const recovered = existing?.available === false;
     const guild = recovered && existing ? existing : new Guild(client, guildData);
 
-    if (recovered) refreshRecoveredGuild(guild, g);
+    if (recovered) {
+      guild._patch(guildData);
+      refreshRecoveredGuild(guild, g);
+    }
     client.guilds.set(guild.id, guild);
 
     for (const ch of g.channels ?? []) {

--- a/packages/fluxer-core/src/test/fixtures.ts
+++ b/packages/fluxer-core/src/test/fixtures.ts
@@ -18,7 +18,7 @@ export function fixtureUser(overrides: Partial<APIUserPartial> = {}): APIUserPar
   };
 }
 
-/** Minimal guild payload that passes {@link normalizeGuildPayload}. */
+/** Minimal flat guild payload accepted by the guild payload normalizers. */
 export function fixtureGuild(overrides: Partial<APIGuild> = {}): APIGuild {
   return {
     id: '200000000000000001',

--- a/packages/fluxer-core/src/util/guildUtils.test.ts
+++ b/packages/fluxer-core/src/util/guildUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { normalizeGuildPayload } from './guildUtils.js';
+import { normalizeGuildSnapshotPayload, normalizeGuildUpdatePayload } from './guildUtils.js';
 
 const guildProperties = {
   id: 'g1',
@@ -17,7 +17,7 @@ const guildProperties = {
   default_message_notifications: 0,
 };
 
-describe('normalizeGuildPayload', () => {
+describe('normalizeGuildSnapshotPayload', () => {
   it('unwraps nested gateway properties and preserves top-level roles', () => {
     const roles = [
       {
@@ -32,7 +32,7 @@ describe('normalizeGuildPayload', () => {
     ];
 
     expect(
-      normalizeGuildPayload({
+      normalizeGuildSnapshotPayload({
         id: 'g1',
         properties: guildProperties,
         roles,
@@ -42,16 +42,69 @@ describe('normalizeGuildPayload', () => {
     ).toEqual({ ...guildProperties, roles });
   });
 
-  it('preserves flat REST and guild update payloads', () => {
-    expect(normalizeGuildPayload(guildProperties)).toBe(guildProperties);
-    expect(normalizeGuildPayload({ id: 'g1', name: 'Updated Guild' })).toEqual({
-      id: 'g1',
-      name: 'Updated Guild',
-    });
+  it('preserves legacy flat snapshots', () => {
+    expect(normalizeGuildSnapshotPayload(guildProperties)).toBe(guildProperties);
   });
 
-  it('rejects malformed nested properties', () => {
-    expect(normalizeGuildPayload({ id: 'g1', properties: null })).toBeNull();
-    expect(normalizeGuildPayload({ id: 'g1', properties: 'invalid' })).toBeNull();
+  it('preserves a flat snapshot with an unrelated future properties field', () => {
+    const payload = { ...guildProperties, properties: { discovery: 'enabled' } };
+
+    expect(normalizeGuildSnapshotPayload(payload)).toBe(payload);
+  });
+
+  it('rejects nested snapshots whose inner and outer IDs differ', () => {
+    expect(
+      normalizeGuildSnapshotPayload({ id: 'other-guild', properties: guildProperties }),
+    ).toBeNull();
+  });
+
+  it('rejects nested snapshots without a complete hydratable identity', () => {
+    expect(
+      normalizeGuildSnapshotPayload({
+        id: 'g1',
+        properties: { id: 'g1', owner_id: 'owner1' },
+      }),
+    ).toBeNull();
+    expect(
+      normalizeGuildSnapshotPayload({
+        id: 'g1',
+        properties: { id: 'g1', name: 'Missing owner' },
+      }),
+    ).toBeNull();
+  });
+
+  it('rejects snapshots with invalid top-level roles', () => {
+    expect(
+      normalizeGuildSnapshotPayload({
+        id: 'g1',
+        properties: guildProperties,
+        roles: 'invalid',
+      }),
+    ).toBeNull();
+  });
+
+  it('rejects payloads that are valid as both flat and nested snapshots', () => {
+    expect(
+      normalizeGuildSnapshotPayload({
+        ...guildProperties,
+        properties: guildProperties,
+      }),
+    ).toBeNull();
+  });
+
+  it.each([null, 'invalid', []])('rejects malformed nested properties: %j', (properties) => {
+    expect(normalizeGuildSnapshotPayload({ id: 'g1', properties })).toBeNull();
+  });
+});
+
+describe('normalizeGuildUpdatePayload', () => {
+  it('preserves flat partial updates without interpreting properties', () => {
+    const payload = {
+      id: 'g1',
+      name: 'Updated Guild',
+      properties: { ...guildProperties, name: 'Wrong Guild' },
+    };
+
+    expect(normalizeGuildUpdatePayload(payload)).toBe(payload);
   });
 });

--- a/packages/fluxer-core/src/util/guildUtils.test.ts
+++ b/packages/fluxer-core/src/util/guildUtils.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeGuildPayload } from './guildUtils.js';
+
+const guildProperties = {
+  id: 'g1',
+  name: 'Test Guild',
+  icon: null,
+  banner: null,
+  splash: null,
+  owner_id: 'owner1',
+  features: [],
+  afk_timeout: 0,
+  nsfw_level: 0,
+  verification_level: 0,
+  mfa_level: 0,
+  explicit_content_filter: 0,
+  default_message_notifications: 0,
+};
+
+describe('normalizeGuildPayload', () => {
+  it('unwraps nested gateway properties and preserves top-level roles', () => {
+    const roles = [
+      {
+        id: 'r1',
+        name: 'Role',
+        color: 0,
+        position: 1,
+        permissions: '0',
+        hoist: false,
+        mentionable: false,
+      },
+    ];
+
+    expect(
+      normalizeGuildPayload({
+        id: 'g1',
+        properties: guildProperties,
+        roles,
+        channels: [],
+        members: [],
+      }),
+    ).toEqual({ ...guildProperties, roles });
+  });
+
+  it('preserves flat REST and guild update payloads', () => {
+    expect(normalizeGuildPayload(guildProperties)).toBe(guildProperties);
+    expect(normalizeGuildPayload({ id: 'g1', name: 'Updated Guild' })).toEqual({
+      id: 'g1',
+      name: 'Updated Guild',
+    });
+  });
+
+  it('rejects malformed nested properties', () => {
+    expect(normalizeGuildPayload({ id: 'g1', properties: null })).toBeNull();
+    expect(normalizeGuildPayload({ id: 'g1', properties: 'invalid' })).toBeNull();
+  });
+});

--- a/packages/fluxer-core/src/util/guildUtils.ts
+++ b/packages/fluxer-core/src/util/guildUtils.ts
@@ -1,15 +1,30 @@
 import type { APIGuild, APIRole } from '@fluxerjs/types';
 
+export type GatewayGuildPayload =
+  | APIGuild
+  | {
+      id: string;
+      properties: APIGuild;
+      roles?: APIRole[];
+    };
+
 /**
  * Validate and coerce a gateway guild payload to {@link APIGuild}.
- * Requires a string `id`. Other fields are type-checked only when present
- * (GUILD_UPDATE payloads are often partial).
+ * Supports flat REST/update payloads and gateway snapshots with metadata nested under
+ * `properties`. Requires a string `id`; other fields are type-checked only when present.
  */
-export function normalizeGuildPayload(
-  raw: APIGuild | null | undefined | unknown,
-): (APIGuild & { roles?: APIRole[] }) | null {
+export function normalizeGuildPayload(raw: unknown): (APIGuild & { roles?: APIRole[] }) | null {
   if (!raw || typeof raw !== 'object') return null;
-  const o = raw as Record<string, unknown>;
+  const gatewayPayload = raw as Record<string, unknown>;
+  let o = gatewayPayload;
+
+  if ('properties' in gatewayPayload) {
+    if (!gatewayPayload.properties || typeof gatewayPayload.properties !== 'object') return null;
+    o = {
+      ...(gatewayPayload.properties as Record<string, unknown>),
+      roles: gatewayPayload.roles,
+    };
+  }
 
   if (typeof o.id !== 'string' || o.id.length === 0) return null;
   if ('name' in o && typeof o.name !== 'string') return null;
@@ -30,5 +45,5 @@ export function normalizeGuildPayload(
   if ('icon' in o && o.icon !== null && typeof o.icon !== 'string') return null;
   if ('banner' in o && o.banner !== null && typeof o.banner !== 'string') return null;
 
-  return raw as APIGuild & { roles?: APIRole[] };
+  return o as unknown as APIGuild & { roles?: APIRole[] };
 }

--- a/packages/fluxer-core/src/util/guildUtils.ts
+++ b/packages/fluxer-core/src/util/guildUtils.ts
@@ -8,29 +8,18 @@ export type GatewayGuildPayload =
       roles?: APIRole[];
     };
 
-/**
- * Validate and coerce a gateway guild payload to {@link APIGuild}.
- * Supports flat REST/update payloads and gateway snapshots with metadata nested under
- * `properties`. Requires a string `id`; other fields are type-checked only when present.
- */
-export function normalizeGuildPayload(raw: unknown): (APIGuild & { roles?: APIRole[] }) | null {
-  if (!raw || typeof raw !== 'object') return null;
-  const gatewayPayload = raw as Record<string, unknown>;
-  let o = gatewayPayload;
+type NormalizedGuildPayload = APIGuild & { roles?: APIRole[] };
 
-  if ('properties' in gatewayPayload) {
-    if (!gatewayPayload.properties || typeof gatewayPayload.properties !== 'object') return null;
-    o = {
-      ...(gatewayPayload.properties as Record<string, unknown>),
-      roles: gatewayPayload.roles,
-    };
-  }
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
 
-  if (typeof o.id !== 'string' || o.id.length === 0) return null;
-  if ('name' in o && typeof o.name !== 'string') return null;
-  if ('owner_id' in o && typeof o.owner_id !== 'string') return null;
-  if ('features' in o && !Array.isArray(o.features)) return null;
-  if ('afk_timeout' in o && typeof o.afk_timeout !== 'number') return null;
+function isValidGuildPayload(o: Record<string, unknown>): boolean {
+  if (!Object.hasOwn(o, 'id') || typeof o.id !== 'string' || o.id.length === 0) return false;
+  if ('name' in o && typeof o.name !== 'string') return false;
+  if ('owner_id' in o && typeof o.owner_id !== 'string') return false;
+  if ('features' in o && !Array.isArray(o.features)) return false;
+  if ('afk_timeout' in o && typeof o.afk_timeout !== 'number') return false;
 
   for (const key of [
     'verification_level',
@@ -39,11 +28,54 @@ export function normalizeGuildPayload(raw: unknown): (APIGuild & { roles?: APIRo
     'explicit_content_filter',
     'default_message_notifications',
   ] as const) {
-    if (key in o && typeof o[key] !== 'number') return null;
+    if (key in o && typeof o[key] !== 'number') return false;
   }
 
-  if ('icon' in o && o.icon !== null && typeof o.icon !== 'string') return null;
-  if ('banner' in o && o.banner !== null && typeof o.banner !== 'string') return null;
+  if ('icon' in o && o.icon !== null && typeof o.icon !== 'string') return false;
+  if ('banner' in o && o.banner !== null && typeof o.banner !== 'string') return false;
 
-  return o as unknown as APIGuild & { roles?: APIRole[] };
+  return true;
+}
+
+function isHydratableGuildPayload(o: Record<string, unknown>): boolean {
+  return (
+    isValidGuildPayload(o) &&
+    Object.hasOwn(o, 'name') &&
+    typeof o.name === 'string' &&
+    Object.hasOwn(o, 'owner_id') &&
+    typeof o.owner_id === 'string'
+  );
+}
+
+/**
+ * Normalize a READY/GUILD_CREATE snapshot to {@link APIGuild}.
+ * Current gateway snapshots nest metadata under `properties`; full flat snapshots remain
+ * supported for backwards compatibility.
+ */
+export function normalizeGuildSnapshotPayload(raw: unknown): NormalizedGuildPayload | null {
+  if (!isRecord(raw)) return null;
+
+  const flatPayload =
+    isHydratableGuildPayload(raw) && (raw.roles === undefined || Array.isArray(raw.roles))
+      ? raw
+      : null;
+
+  let nestedPayload: Record<string, unknown> | null = null;
+  if (Object.hasOwn(raw, 'properties') && isRecord(raw.properties)) {
+    const properties = raw.properties;
+    const rolesValid = raw.roles === undefined || Array.isArray(raw.roles);
+    if (rolesValid && isHydratableGuildPayload(properties) && raw.id === properties.id) {
+      nestedPayload = { ...properties };
+      if (raw.roles !== undefined) nestedPayload.roles = raw.roles;
+    }
+  }
+
+  if ((flatPayload === null) === (nestedPayload === null)) return null;
+  return (flatPayload ?? nestedPayload) as unknown as NormalizedGuildPayload;
+}
+
+/** Validate a flat GUILD_UPDATE payload without interpreting unknown fields. */
+export function normalizeGuildUpdatePayload(raw: unknown): NormalizedGuildPayload | null {
+  if (!isRecord(raw) || !isValidGuildPayload(raw)) return null;
+  return raw as unknown as NormalizedGuildPayload;
 }


### PR DESCRIPTION
## Description

Gateway guild snapshots provide guild metadata under a nested `properties` object

The existing normalization logic validated the outer guild ID but passed the wrapper directly to `Guild`

`Guild` expects fields such as `name`, `icon`, and `owner_id` at the top level

This caused cached guilds created from `READY` or `GUILD_CREATE` to contain missing or null metadata

> [!NOTE]
> This is a regression from the v2 rewrite
>
> The v1 implementation unwrapped the nested `properties` object before constructing guilds, but that behavior was lost during the rewrite

This change:

- Unwraps nested gateway guild `properties` before guild hydration
- Preserves top-level gateway resources such as roles
- Continues to support flat REST and guild-update payloads
- Applies normalized data when recovering temporarily unavailable guilds
- Adds regression coverage for `READY`, `GUILD_CREATE`, cached fetches, recovery, and malformed payloads

As a result, `client.guilds.cache.get()` and cache-first `client.guilds.fetch()` return fully hydrated guild metadata.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] My code follows the project's style guidelines (run `pnpm run lint`)
- [x] I have run `pnpm run build` successfully
- [x] The full test suite passed via `pnpm run gate:pre-merge`