### PR TITLE
fix: allow permitted external emoji reactions

### DIFF
--- a/.changeset/allow-external-reactions.md
+++ b/.changeset/allow-external-reactions.md
@@ -1,0 +1,5 @@
+---
+'@fluxerjs/core': patch
+---
+
+Allow reactions with external custom emojis when permitted by Fluxer.

--- a/packages/fluxer-core/src/client/Client.resolveEmoji.test.ts
+++ b/packages/fluxer-core/src/client/Client.resolveEmoji.test.ts
@@ -18,12 +18,16 @@ describe('Client.resolveEmoji', () => {
   });
 
   it('resolves object with id without guild lookup', async () => {
-    const result = await client.resolveEmoji({
-      name: 'custom',
-      id: '123456789012345678',
-    });
+    const result = await client.resolveEmoji(
+      {
+        name: 'custom',
+        id: '123456789012345678',
+      },
+      '987654321098765432',
+    );
     expect(result).toContain('custom');
     expect(result).toContain('123456789012345678');
+    expect(client.rest.get).not.toHaveBeenCalled();
   });
 
   it('resolves name:id string format', async () => {
@@ -32,10 +36,11 @@ describe('Client.resolveEmoji', () => {
     expect(result).toContain('123456789012345678');
   });
 
-  it('resolves <:name:id> mention format', async () => {
-    const result = await client.resolveEmoji('<:custom:123456789012345678>');
+  it('resolves <:name:id> mention format without guild lookup', async () => {
+    const result = await client.resolveEmoji('<:custom:123456789012345678>', '987654321098765432');
     expect(result).toContain('custom');
     expect(result).toContain('123456789012345678');
+    expect(client.rest.get).not.toHaveBeenCalled();
   });
 
   it('returns raw unicode for direct unicode input', async () => {

--- a/packages/fluxer-core/src/client/clientEmoji.ts
+++ b/packages/fluxer-core/src/client/clientEmoji.ts
@@ -26,23 +26,6 @@ import type { Client } from './Client.js';
 import { toBulkFetchWire, type BulkFetchMessagesRequest } from './sdkOptions.js';
 
 /**
- * Asserts that a custom emoji (by id) belongs to the given guild.
- * @throws FluxerError with EMOJI_NOT_IN_GUILD if the emoji is not in the guild
- */
-export async function assertEmojiInGuild(
-  client: Client,
-  emojiId: string,
-  guildId: string,
-): Promise<void> {
-  const emojis = await client.rest.get<APIEmoji[]>(Routes.guildEmojis(guildId));
-  if (!emojis.some((e) => e.id === emojiId)) {
-    throw new FluxerError('Custom emoji is from another server. Use an emoji from this server.', {
-      code: ErrorCodes.EmojiNotInGuild,
-    });
-  }
-}
-
-/**
  * Resolve an emoji argument to the API format (unicode or "name:id").
  * Supports: <:name:id>, :name:, name:id, { name, id }, unicode.
  * When id is missing (e.g. :name:), fetches guild emojis if guildId provided.
@@ -53,7 +36,6 @@ export async function resolveClientEmoji(
   guildId?: string | null,
 ): Promise<string> {
   if (typeof emoji === 'object' && emoji.id) {
-    if (guildId) await assertEmojiInGuild(client, emoji.id, guildId);
     return formatEmoji({ name: emoji.name, id: emoji.id, animated: emoji.animated });
   }
   const parsed = parseEmoji(
@@ -63,7 +45,6 @@ export async function resolveClientEmoji(
     throw new FluxerError('Invalid emoji', { code: ErrorCodes.InvalidEmoji });
   }
   if (parsed.id) {
-    if (guildId) await assertEmojiInGuild(client, parsed.id, guildId);
     return formatEmoji(parsed);
   }
   if (!/^\w+$/.test(parsed.name)) return parsed.name;


### PR DESCRIPTION
## Description

Fix external custom emoji reactions being incorrectly rejected by the SDK.

Gateway messages include a guild ID, so the SDK ran its same-server check and rejected external emojis. Messages returned by `channel.send()` do not include a guild ID, so the check was skipped and the same reaction worked.

The fix removes this SDK check only for explicit emoji IDs such as `<:name:id>` and `name:id`. Both paths now send the emoji to Fluxer, where permissions and external emoji access are validated correctly.

Name-only inputs such as `:name:` still use the existing guild lookup.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
## Checklist

- [x] My code follows the project's style guidelines (run `pnpm run lint`)
- [x] I have run `pnpm run build` successfully
- [x] I have run `pnpm run test` successfully
