### PR TITLE
fix(core): preserve guild member counts

### DIFF
--- a/.changeset/calm-guilds-count.md
+++ b/.changeset/calm-guilds-count.md
@@ -1,0 +1,6 @@
+---
+'@fluxerjs/core': patch
+'@fluxerjs/types': patch
+---
+
+Preserve guild member counts from REST and gateway payloads.

--- a/packages/fluxer-core/src/client/Client.gateway.test.ts
+++ b/packages/fluxer-core/src/client/Client.gateway.test.ts
@@ -75,6 +75,23 @@ describe('Client gateway helpers and dispatch', () => {
     expect(get).not.toHaveBeenCalled();
   });
 
+  it('preserves the last known member count when a repeated READY omits it', () => {
+    const existing = new Guild(client, fixtureGuild({ member_count: 42 }));
+    existing.memberCount = 43;
+    client.guilds.set(existing.id, existing);
+
+    hydrateReadyGuilds(client, [fixtureGuild({ name: 'Refreshed guild' })], false);
+
+    expect(client.guilds.get(existing.id)).toMatchObject({
+      name: 'Refreshed guild',
+      memberCount: 43,
+    });
+
+    hydrateReadyGuilds(client, [fixtureGuild({ name: 'Counted guild', member_count: 44 })], false);
+
+    expect(client.guilds.get(existing.id)?.memberCount).toBe(44);
+  });
+
   it('updates cached guild member counts from GUILD_COUNTS_UPDATE', async () => {
     const guild = new Guild(client, fixtureGuild());
     client.guilds.set(guild.id, guild);

--- a/packages/fluxer-core/src/client/Client.gateway.test.ts
+++ b/packages/fluxer-core/src/client/Client.gateway.test.ts
@@ -3,6 +3,7 @@ import { Routes } from '@fluxerjs/types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Guild } from '../structures/Guild.js';
 import { Invite } from '../structures/Invite.js';
+import { fixtureGuild } from '../test/fixtures.js';
 import { Events } from '../util/Events.js';
 import { Client } from './Client.js';
 import { ClientUser } from './ClientUser.js';
@@ -44,6 +45,7 @@ describe('Client gateway helpers and dispatch', () => {
             mfa_level: 0,
             explicit_content_filter: 2,
             default_message_notifications: 1,
+            member_count: 42,
           },
           channels: [],
           roles: [],
@@ -68,8 +70,30 @@ describe('Client gateway helpers and dispatch', () => {
       verificationLevel: 1,
       explicitContentFilter: 2,
       defaultMessageNotifications: 1,
+      memberCount: 42,
     });
     expect(get).not.toHaveBeenCalled();
+  });
+
+  it('updates cached guild member counts from GUILD_COUNTS_UPDATE', async () => {
+    const guild = new Guild(client, fixtureGuild());
+    client.guilds.set(guild.id, guild);
+    const emit = vi.spyOn(client, 'emit');
+
+    await (
+      client as unknown as { handleDispatch: (payload: unknown) => Promise<void> }
+    ).handleDispatch({
+      op: 0,
+      t: 'GUILD_COUNTS_UPDATE',
+      d: {
+        counts: [{ guild_id: guild.id, member_count: 43, online_count: 7 }],
+      },
+    });
+
+    expect(guild.memberCount).toBe(43);
+    expect(emit).toHaveBeenCalledWith(Events.GuildCountsUpdate, {
+      counts: [{ guildId: guild.id, memberCount: 43, onlineCount: 7 }],
+    });
   });
 
   it('fetchGatewayInfo() fetches gateway metadata from /gateway/bot', async () => {

--- a/packages/fluxer-core/src/client/GatewayReady.ts
+++ b/packages/fluxer-core/src/client/GatewayReady.ts
@@ -53,7 +53,11 @@ export function hydrateReadyGuilds(
     }
     const guildData = normalizeGuildSnapshotPayload(g as unknown);
     if (!guildData) continue;
+    const existing = client.guilds.get(guildData.id);
     const guild = new Guild(client, guildData);
+    if (existing && guildData.member_count === undefined) {
+      guild.memberCount = existing.memberCount;
+    }
     client.guilds.set(guild.id, guild);
     for (const ch of g.channels ?? []) {
       const channel = Channel.from(client, ch);

--- a/packages/fluxer-core/src/client/GuildManager.test.ts
+++ b/packages/fluxer-core/src/client/GuildManager.test.ts
@@ -4,7 +4,7 @@ import { fixtureGuild } from '../test/fixtures.js';
 import { Client } from './Client.js';
 
 describe('GuildManager', () => {
-  it('preserves member_count from fetched guilds', async () => {
+  it('preserves member_count from guilds fetched on a cache miss', async () => {
     const client = new Client();
     const data = fixtureGuild({ member_count: 42 });
     const get = vi.spyOn(client.rest, 'get').mockResolvedValue(data);

--- a/packages/fluxer-core/src/client/GuildManager.test.ts
+++ b/packages/fluxer-core/src/client/GuildManager.test.ts
@@ -1,0 +1,17 @@
+import { Routes } from '@fluxerjs/types';
+import { describe, expect, it, vi } from 'vitest';
+import { fixtureGuild } from '../test/fixtures.js';
+import { Client } from './Client.js';
+
+describe('GuildManager', () => {
+  it('preserves member_count from fetched guilds', async () => {
+    const client = new Client();
+    const data = fixtureGuild({ member_count: 42 });
+    const get = vi.spyOn(client.rest, 'get').mockResolvedValue(data);
+
+    const guild = await client.guilds.fetch(data.id);
+
+    expect(get).toHaveBeenCalledWith(Routes.guild(data.id));
+    expect(guild.memberCount).toBe(42);
+  });
+});

--- a/packages/fluxer-core/src/client/eventHandlers/guilds.test.ts
+++ b/packages/fluxer-core/src/client/eventHandlers/guilds.test.ts
@@ -90,6 +90,27 @@ describe('guild availability lifecycle', () => {
     });
   });
 
+  it('preserves the last known member count when a repeated GUILD_CREATE omits it', async () => {
+    const client = new Client({ gatewayDeferHandlers: false });
+    const existing = new Guild(client, { ...guildPayload('Existing guild'), member_count: 42 });
+    existing.memberCount = 43;
+    client.guilds.set(existing.id, existing);
+
+    await dispatch(client, 'GUILD_CREATE', guildPayload('Refreshed guild'));
+
+    expect(client.guilds.get(existing.id)).toMatchObject({
+      name: 'Refreshed guild',
+      memberCount: 43,
+    });
+
+    await dispatch(client, 'GUILD_CREATE', {
+      ...guildPayload('Counted guild'),
+      member_count: 44,
+    });
+
+    expect(client.guilds.get(existing.id)?.memberCount).toBe(44);
+  });
+
   it('treats GUILD_UPDATE as flat when it contains a properties field', async () => {
     const client = new Client({ gatewayDeferHandlers: false });
     const guild = new Guild(client, guildPayload('Before update'));

--- a/packages/fluxer-core/src/client/eventHandlers/guilds.ts
+++ b/packages/fluxer-core/src/client/eventHandlers/guilds.ts
@@ -73,6 +73,9 @@ export const guildHandlers: HandlerMap = {
     const recovered = existing?.available === false;
     const guild = recovered && existing ? existing : new Guild(client, guildData);
 
+    if (existing && guild !== existing && guildData.member_count === undefined) {
+      guild.memberCount = existing.memberCount;
+    }
     if (recovered) {
       guild._patch(guildData);
       refreshRecoveredGuild(guild, g);

--- a/packages/fluxer-core/src/client/eventHandlers/passthrough.ts
+++ b/packages/fluxer-core/src/client/eventHandlers/passthrough.ts
@@ -19,7 +19,7 @@ import type {
   WebhooksUpdatePayload,
 } from '../eventPayloads.js';
 
-import { pass, type HandlerMap } from './types.js';
+import { type HandlerMap, pass } from './types.js';
 
 function toPresence(data: GatewayPresenceUpdateDispatchData): PresenceUpdatePayload {
   const custom = data.custom_status;
@@ -123,14 +123,18 @@ export const passthroughHandlers: HandlerMap = {
   GUILD_COUNTS_UPDATE(client, d) {
     const data = d as GatewayGuildCountsUpdateDispatchData;
 
+    const counts = (data.counts ?? []).map((c) => ({
+      guildId: c.guild_id,
+      memberCount: c.member_count,
+      onlineCount: c.online_count,
+    }));
+    for (const count of counts) {
+      const guild = client.guilds.get(count.guildId);
+      if (guild) guild.memberCount = count.memberCount;
+    }
+
     const payload: GuildCountsUpdatePayload = {
-      counts: (data.counts ?? []).map((c) => ({
-        guildId: c.guild_id,
-
-        memberCount: c.member_count,
-
-        onlineCount: c.online_count,
-      })),
+      counts,
     };
 
     client.emit(Events.GuildCountsUpdate, payload);

--- a/packages/fluxer-core/src/structures/Guild.test.ts
+++ b/packages/fluxer-core/src/structures/Guild.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest';
-import { Guild, type Client } from '../';
+import { describe, expect, it } from 'vitest';
+import { type Client, Guild } from '../';
+import { fixtureGuild } from '../test/fixtures.js';
 import { DEFAULT_INSTANCE_ENDPOINTS } from '../util/instance.js';
 
 function createMockClient() {
@@ -84,6 +85,28 @@ describe('Guild', () => {
       const guild = createGuild({ id: 'custom123' });
       expect(guild.id).toBe('custom123');
       expect(guild.name).toBe('Test Guild');
+    });
+
+    it('preserves the member count when provided', () => {
+      const guild = new Guild(createMockClient(), fixtureGuild({ member_count: 42 }));
+      expect(guild.memberCount).toBe(42);
+    });
+
+    it('uses null when no member count is provided', () => {
+      const guild = new Guild(createMockClient(), fixtureGuild());
+      expect(guild.memberCount).toBeNull();
+    });
+  });
+
+  describe('_patch()', () => {
+    it('updates the member count only when provided', () => {
+      const guild = new Guild(createMockClient(), fixtureGuild({ member_count: 42 }));
+
+      guild._patch(fixtureGuild({ member_count: 43 }));
+      expect(guild.memberCount).toBe(43);
+
+      guild._patch(fixtureGuild());
+      expect(guild.memberCount).toBe(43);
     });
   });
 });

--- a/packages/fluxer-core/src/structures/guild/Guild.ts
+++ b/packages/fluxer-core/src/structures/guild/Guild.ts
@@ -11,13 +11,13 @@ import type {
 import { GuildNSFWLevel } from '@fluxerjs/types';
 import type { Client } from '../../client/Client.js';
 import type { AuditLogFetchPayload, VanityURLPayload } from '../../client/eventPayloads.js';
+import { GuildMemberManager } from '../../client/GuildMemberManager.js';
 import type {
   DiscoveryApplicationOptions,
   DiscoveryApplicationPayload,
   DiscoveryStatusPayload,
   SudoVerificationOptions,
 } from '../../client/sdkOptions.js';
-import { GuildMemberManager } from '../../client/GuildMemberManager.js';
 import { Base } from '../Base.js';
 import type { GuildChannel } from '../Channel.js';
 import type { GuildBan } from '../GuildBan.js';
@@ -93,6 +93,8 @@ export class Guild extends Base {
   splashWidth?: number | null;
   /** Splash height in pixels. */
   splashHeight?: number | null;
+  /** Last known member count, or null if no count has been received. */
+  memberCount: number | null;
   /** Member manager for this guild (fetch/add/remove members). */
   members: GuildMemberManager;
   /** Cached channels in this guild. */
@@ -133,6 +135,7 @@ export class Guild extends Base {
     this.bannerHeight = data.banner_height ?? null;
     this.splashWidth = data.splash_width ?? null;
     this.splashHeight = data.splash_height ?? null;
+    this.memberCount = data.member_count ?? null;
     for (const r of data.roles ?? []) {
       this.roles.set(r.id, new Role(client, r, this.id));
     }
@@ -167,6 +170,7 @@ export class Guild extends Base {
     if (data.banner_height !== undefined) this.bannerHeight = data.banner_height ?? null;
     if (data.splash_width !== undefined) this.splashWidth = data.splash_width ?? null;
     if (data.splash_height !== undefined) this.splashHeight = data.splash_height ?? null;
+    if (data.member_count !== undefined) this.memberCount = data.member_count ?? null;
   }
 
   /** Get the full CDN URL for the guild's icon (or null). */

--- a/packages/types/src/api/guild.ts
+++ b/packages/types/src/api/guild.ts
@@ -309,6 +309,8 @@ export interface APIGuild {
   message_history_cutoff?: string | null;
   /** Permissions for the current user in this guild (bitfield string). */
   permissions?: string | null;
+  /** Member count when included in the guild payload. */
+  member_count?: number;
 }
 
 /** Audit log entry from GET /guilds/{id}/audit-logs. */


### PR DESCRIPTION
> [!TIP]
> Merge #56 and #57 as well

## Description

Guild member counts are now available and stay up to date.

Previously, counts returned by the API were not stored on guilds.

This adds `memberCount` to `Guild`, updates it from REST and gateway payloads, and preserves it across partial guild snapshots.

> [!IMPORTANT]
> Fixes #50 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] My code follows the project's style guidelines (run `pnpm run lint`)
- [x] I have run `pnpm run build` successfully
- [x] I have run `pnpm run test` successfully
