### PR TITLE
fix(voice): allow clean LiveKit shutdown

### DIFF
--- a/.changeset/quiet-livekit-shutdown.md
+++ b/.changeset/quiet-livekit-shutdown.md
@@ -1,0 +1,5 @@
+---
+'@fluxerjs/voice': patch
+---
+
+Add an explicit LiveKit shutdown API so applications can release the shared runtime before exiting.

--- a/packages/voice/README.md
+++ b/packages/voice/README.md
@@ -40,3 +40,16 @@ voiceManager.leave(guildId);
 ```
 
 Use yt-dlp to get stream URLs from YouTube. For LiveKit, listen for `serverLeave` to reconnect.
+
+When the process is shutting down, leave every voice channel and dispose the shared LiveKit runtime:
+
+```javascript
+import { shutdownLiveKit } from '@fluxerjs/voice';
+
+voiceManager.leave(guildId);
+await shutdownLiveKit();
+await client.destroy();
+```
+
+`shutdownLiveKit()` is process-wide and final. Call it once during shutdown, after all LiveKit voice
+connections have been left. New LiveKit connections cannot be created afterward.

--- a/packages/voice/src/LiveKitRtcConnection.ts
+++ b/packages/voice/src/LiveKitRtcConnection.ts
@@ -25,6 +25,11 @@ import {
   TrackKind,
 } from '@livekit/rtc-node';
 import { buildLiveKitUrlForRtcSdk } from './livekit.js';
+import {
+  disconnectLiveKitRoom,
+  registerLiveKitRoom,
+  releaseLiveKitRoom,
+} from './livekitRuntime.js';
 import { parseOpusPacketBoundaries, concatUint8Arrays } from './opusUtils.js';
 import { VoiceConnectionEvents } from './VoiceConnection.js';
 import { createReadStream } from 'node:fs';
@@ -490,10 +495,13 @@ export class LiveKitRtcConnection extends EventEmitter {
 
     try {
       const room = new Room();
+      registerLiveKitRoom(room);
       this.room = room;
 
       room.on(RoomEvent.Disconnected, () => {
         this.debug('Room disconnected');
+        releaseLiveKitRoom(room);
+        if (this.room === room) this.room = null;
         this.lastServerEndpoint = null;
         this.lastServerToken = null;
         setImmediate(() => this.emit('serverLeave'));
@@ -559,6 +567,9 @@ export class LiveKitRtcConnection extends EventEmitter {
       this.debug('connected to room');
       this.emit('ready');
     } catch (e) {
+      if (this.room) {
+        disconnectLiveKitRoom(this.room);
+      }
       this.room = null;
       const err = e instanceof Error ? e : new Error(String(e));
       this.emit('error', err);
@@ -1772,7 +1783,7 @@ export class LiveKitRtcConnection extends EventEmitter {
     this._destroyed = true;
     this.stop();
     if (this.room) {
-      this.room.disconnect().catch(() => {});
+      disconnectLiveKitRoom(this.room);
       this.room = null;
     }
     this.lastServerEndpoint = null;

--- a/packages/voice/src/exports.test.ts
+++ b/packages/voice/src/exports.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import { Client } from '@fluxerjs/core';
-import { VoiceManager, VoiceConnection, LiveKitRtcConnection, getVoiceManager } from './index.js';
+import {
+  VoiceManager,
+  VoiceConnection,
+  LiveKitRtcConnection,
+  getVoiceManager,
+  shutdownLiveKit,
+} from './index.js';
 
 describe('@fluxerjs/voice exports', () => {
   it('exports VoiceManager class', () => {
@@ -21,6 +27,10 @@ describe('@fluxerjs/voice exports', () => {
   it('exports getVoiceManager function', () => {
     expect(getVoiceManager).toBeDefined();
     expect(typeof getVoiceManager).toBe('function');
+  });
+
+  it('exports shutdownLiveKit function', () => {
+    expect(typeof shutdownLiveKit).toBe('function');
   });
 
   it('getVoiceManager returns VoiceManager for a client', () => {

--- a/packages/voice/src/index.ts
+++ b/packages/voice/src/index.ts
@@ -7,6 +7,7 @@ export {
   type LiveKitReceiveSubscription,
   type VideoPlayOptions,
 } from './LiveKitRtcConnection.js';
+export { shutdownLiveKit } from './livekitRuntime.js';
 import { Client } from '@fluxerjs/core';
 import { VoiceChannel } from '@fluxerjs/core';
 import { VoiceManager } from './VoiceManager.js';

--- a/packages/voice/src/livekitRuntime.test.ts
+++ b/packages/voice/src/livekitRuntime.test.ts
@@ -1,0 +1,57 @@
+import type { Room } from '@livekit/rtc-node';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+const { dispose } = vi.hoisted(() => ({
+  dispose: vi.fn<() => Promise<void>>().mockResolvedValue(),
+}));
+
+vi.mock('@livekit/rtc-node', () => ({ dispose }));
+
+describe('LiveKit runtime shutdown', () => {
+  let disconnectLiveKitRoom: (room: Room) => void;
+  let registerLiveKitRoom: (room: Room) => void;
+  let releaseLiveKitRoom: (room: Room) => void;
+  let shutdownLiveKit: () => Promise<void>;
+
+  beforeAll(async () => {
+    ({ disconnectLiveKitRoom, registerLiveKitRoom, releaseLiveKitRoom, shutdownLiveKit } =
+      await import('./livekitRuntime.js'));
+  });
+
+  it('waits for room cleanup and prevents reuse after terminal shutdown', async () => {
+    let finishDisconnect: (() => void) | undefined;
+    const disconnect = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishDisconnect = resolve;
+        }),
+    );
+    const room = { disconnect } as unknown as Room;
+    const serverDisconnectedRoom = {} as Room;
+
+    registerLiveKitRoom(room);
+    registerLiveKitRoom(serverDisconnectedRoom);
+    releaseLiveKitRoom(serverDisconnectedRoom);
+    await expect(shutdownLiveKit()).rejects.toThrow(
+      'Cannot shut down LiveKit while voice connections are still active',
+    );
+    expect(dispose).not.toHaveBeenCalled();
+
+    disconnectLiveKitRoom(room);
+    disconnectLiveKitRoom(room);
+    const shutdown = shutdownLiveKit();
+    await Promise.resolve();
+    expect(disconnect).toHaveBeenCalledOnce();
+    expect(dispose).not.toHaveBeenCalled();
+
+    finishDisconnect?.();
+    await shutdown;
+    expect(dispose).toHaveBeenCalledOnce();
+
+    expect(() => registerLiveKitRoom(room)).toThrow(
+      'LiveKit has been shut down and cannot create new voice connections',
+    );
+    await expect(shutdownLiveKit()).resolves.toBeUndefined();
+    expect(dispose).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/voice/src/livekitRuntime.ts
+++ b/packages/voice/src/livekitRuntime.ts
@@ -1,0 +1,56 @@
+import { dispose, type Room } from '@livekit/rtc-node';
+
+const activeRooms = new Set<Room>();
+const pendingDisconnects = new Set<Promise<void>>();
+const roomDisconnects = new WeakMap<Room, Promise<void>>();
+let shutdownPromise: Promise<void> | null = null;
+let shutdownStarted = false;
+
+export function registerLiveKitRoom(room: Room): void {
+  if (shutdownStarted) {
+    throw new Error('LiveKit has been shut down and cannot create new voice connections');
+  }
+  activeRooms.add(room);
+}
+
+export function releaseLiveKitRoom(room: Room): void {
+  activeRooms.delete(room);
+}
+
+export function disconnectLiveKitRoom(room: Room): void {
+  releaseLiveKitRoom(room);
+  if (roomDisconnects.has(room)) return;
+
+  let pending: Promise<void>;
+  pending = Promise.resolve()
+    .then(() => room.disconnect())
+    .finally(() => pendingDisconnects.delete(pending));
+  roomDisconnects.set(room, pending);
+  pendingDisconnects.add(pending);
+
+  // Individual connection teardown remains synchronous for compatibility.
+  // shutdownLiveKit() observes pending cleanup before disposing the shared runtime.
+  void pending.catch(() => {});
+}
+
+/**
+ * Dispose the process-wide LiveKit runtime.
+ *
+ * Call this once, after leaving every LiveKit voice channel, when the process is
+ * shutting down. LiveKit cannot create new connections after this resolves.
+ */
+export function shutdownLiveKit(): Promise<void> {
+  if (shutdownPromise) return shutdownPromise;
+  if (activeRooms.size > 0) {
+    return Promise.reject(
+      new Error('Cannot shut down LiveKit while voice connections are still active'),
+    );
+  }
+
+  shutdownStarted = true;
+  shutdownPromise = (async () => {
+    await Promise.allSettled([...pendingDisconnects]);
+    await dispose();
+  })();
+  return shutdownPromise;
+}


### PR DESCRIPTION
> [!TIP]
> Merge #53 and #57 as well

## Description

Bots can now shut down cleanly after using LiveKit voice.

Previously, leaving voice disconnected the room but kept LiveKit's shared runtime alive, which could stop Node.js from exiting.

This adds `shutdownLiveKit()`. Call it once after leaving all voice channels when the bot is shutting down. It waits for room cleanup and releases the shared runtime.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist

- [x] My code follows the project's style guidelines (run `pnpm run lint`)
- [x] I have run `pnpm run build` successfully
- [x] I have run `pnpm run test` successfully
