### PR TITLE
feat: add client uptime and gateway ping

### DIFF
--- a/.changeset/quiet-clocks-measure.md
+++ b/.changeset/quiet-clocks-measure.md
@@ -1,0 +1,6 @@
+---
+'@fluxerjs/core': minor
+'@fluxerjs/ws': minor
+---
+
+Add client uptime and gateway heartbeat latency getters.

--- a/examples/ping-bot.js
+++ b/examples/ping-bot.js
@@ -35,27 +35,21 @@ function formatUptime(ms) {
   return parts.join(' ');
 }
 
-async function measureApiLatency(client) {
-  const start = Date.now();
-  try {
-    await client.rest.get(Routes.gatewayBot());
-  } catch {
-    // Round-trip only
-  }
-  return Date.now() - start;
-}
-
 /** @type {Map<string, { description: string, execute: Function }>} */
 const commands = new Map();
 
 commands.set('ping', {
-  description: 'Check API latency',
+  description: 'Check gateway latency',
   async execute(message, client) {
-    const apiLatency = await measureApiLatency(client);
+    const gatewayLatency = client.ws.ping;
     const embed = new EmbedBuilder()
       .setTitle('Pong!')
       .setColor(BRAND_COLOR)
-      .addFields({ name: 'API Latency', value: `\`${apiLatency}ms\``, inline: true })
+      .addFields({
+        name: 'Gateway Latency',
+        value: gatewayLatency === null ? '`Measuring…`' : `\`${gatewayLatency}ms\``,
+        inline: true,
+      })
       .setFooter({ text: 'Fluxer Bot' })
       .setTimestamp();
     await message.reply({ embeds: [embed] });
@@ -65,8 +59,8 @@ commands.set('ping', {
 commands.set('info', {
   description: 'Display bot information',
   async execute(message, client) {
-    const uptime = client.readyAt ? Date.now() - client.readyAt.getTime() : 0;
-    const apiLatency = await measureApiLatency(client);
+    const uptime = client.uptime;
+    const gatewayLatency = client.ws.ping;
     const embed = new EmbedBuilder()
       .setTitle('Bot Information')
       .setColor(BRAND_COLOR)
@@ -75,8 +69,16 @@ commands.set('info', {
         { name: 'Username', value: client.user?.username ?? 'Unknown', inline: true },
         { name: 'Guilds', value: `${client.guilds.size}`, inline: true },
         { name: 'Channels', value: `${client.channels.size}`, inline: true },
-        { name: 'Uptime', value: formatUptime(uptime), inline: true },
-        { name: 'API Latency', value: `${apiLatency}ms`, inline: true },
+        {
+          name: 'Uptime',
+          value: uptime === null ? 'Unavailable' : formatUptime(uptime),
+          inline: true,
+        },
+        {
+          name: 'Gateway Latency',
+          value: gatewayLatency === null ? 'Measuring…' : `${gatewayLatency}ms`,
+          inline: true,
+        },
         { name: 'Node.js', value: process.version, inline: true },
       )
       .setFooter({ text: 'Powered by @fluxerjs/core' })

--- a/packages/fluxer-core/src/ClientCore/Client.ts
+++ b/packages/fluxer-core/src/ClientCore/Client.ts
@@ -103,6 +103,10 @@ export class Client extends EventEmitter {
   user: ClientUser | null = null;
   /** Timestamp when the client became ready. Null until READY is received. */
   readyAt: Date | null = null;
+  /** Milliseconds since the client became ready. Null until READY is received. */
+  get uptime(): number | null {
+    return this.readyAt === null ? null : Date.now() - this.readyAt.getTime();
+  }
   /** @internal WebSocket manager. */
   _ws: WebSocketManager | null = null;
   /** When waitForGuilds, guild IDs still expected via GUILD_CREATE. */

--- a/packages/fluxer-core/src/ClientCore/ClientGateway.test.ts
+++ b/packages/fluxer-core/src/ClientCore/ClientGateway.test.ts
@@ -16,6 +16,16 @@ describe('Client gateway helpers and dispatch', () => {
     client = new Client();
   });
 
+  it('reports uptime from readyAt', () => {
+    expect(client.uptime).toBeNull();
+    client.readyAt = new Date(1_000);
+    const now = vi.spyOn(Date, 'now').mockReturnValue(2_500);
+
+    expect(client.uptime).toBe(1_500);
+
+    now.mockRestore();
+  });
+
   it('applies configured cache limits', () => {
     client = new Client({ cache: { guilds: 1, channels: 1, users: 1 } });
     for (const manager of [client.guilds, client.channels, client.users]) {

--- a/packages/ws/src/WebSocketManager.test.ts
+++ b/packages/ws/src/WebSocketManager.test.ts
@@ -37,4 +37,40 @@ describe('WebSocketManager.connect', () => {
     expect(errors).toHaveLength(1);
     expect(errors[0]).toBe(fatal);
   });
+
+  it('averages available heartbeat latency samples', async () => {
+    const manager = new WebSocketManager({
+      token: 'test-token',
+      intents: 0,
+      rest: {
+        get: vi.fn().mockResolvedValue({
+          url: 'wss://gateway.fluxer.app',
+          shards: 2,
+          session_start_limit: {
+            total: 1_000,
+            remaining: 999,
+            reset_after: 60_000,
+            max_concurrency: 1,
+          },
+        }),
+      },
+      WebSocket: FakeWebSocket,
+    });
+
+    await manager.connect();
+    const shards = (
+      manager as unknown as {
+        shards: Map<number, { _ping: number | null }>;
+      }
+    ).shards;
+
+    expect(manager.ping).toBeNull();
+    shards.get(0)!._ping = 20;
+    expect(manager.ping).toBe(20);
+    shards.get(1)!._ping = 40;
+    expect(manager.ping).toBe(30);
+
+    manager.destroy();
+    expect(manager.ping).toBeNull();
+  });
 });

--- a/packages/ws/src/WebSocketManager.ts
+++ b/packages/ws/src/WebSocketManager.ts
@@ -84,6 +84,18 @@ export class WebSocketManager extends EventEmitter {
     this.options = options;
   }
 
+  /** Average heartbeat latency across managed shards with a current sample. */
+  get ping(): number | null {
+    let total = 0;
+    let count = 0;
+    for (const shard of this.shards.values()) {
+      if (shard.ping === null) continue;
+      total += shard.ping;
+      count++;
+    }
+    return count === 0 ? null : total / count;
+  }
+
   async connect(): Promise<void> {
     this.aborted = false;
     const emitManagerError = (error: Error): void => {

--- a/packages/ws/src/WebSocketShard.test.ts
+++ b/packages/ws/src/WebSocketShard.test.ts
@@ -173,4 +173,53 @@ describe('WebSocketShard', () => {
     shard.handlePayload({ op: GatewayOpcodes.HeartbeatAck });
     expect((shard as unknown as { lastHeartbeatAck: boolean }).lastHeartbeatAck).toBe(true);
   });
+
+  it('measures heartbeat round-trip latency', () => {
+    const clock = vi.spyOn(performance, 'now').mockReturnValueOnce(100).mockReturnValueOnce(137);
+    const socket = new MockWebSocket('wss://gateway.fluxer.app');
+    const shard = new WebSocketShard({
+      url: 'wss://gateway.fluxer.app',
+      token: 'test-token',
+      intents: 0,
+      shardId: 0,
+      numShards: 1,
+      WebSocket: MockWebSocket,
+    });
+    (shard as unknown as { ws: MockWebSocket }).ws = socket;
+
+    (shard as unknown as { sendHeartbeat: () => void }).sendHeartbeat();
+    expect(shard.ping).toBeNull();
+
+    shard.handlePayload({ op: GatewayOpcodes.HeartbeatAck });
+    expect(shard.ping).toBe(37);
+
+    shard.destroy();
+    expect(shard.ping).toBeNull();
+    clock.mockRestore();
+  });
+
+  it('keeps the first timestamp when heartbeats overlap before an ack', () => {
+    let now = 100;
+    const clock = vi.spyOn(performance, 'now').mockImplementation(() => now);
+    const socket = new MockWebSocket('wss://gateway.fluxer.app');
+    const shard = new WebSocketShard({
+      url: 'wss://gateway.fluxer.app',
+      token: 'test-token',
+      intents: 0,
+      shardId: 0,
+      numShards: 1,
+      WebSocket: MockWebSocket,
+    });
+    (shard as unknown as { ws: MockWebSocket }).ws = socket;
+
+    (shard as unknown as { sendHeartbeat: () => void }).sendHeartbeat();
+    now = 125;
+    shard.handlePayload({ op: GatewayOpcodes.Heartbeat });
+    now = 137;
+    shard.handlePayload({ op: GatewayOpcodes.HeartbeatAck });
+
+    expect(shard.ping).toBe(37);
+    shard.destroy();
+    clock.mockRestore();
+  });
 });

--- a/packages/ws/src/WebSocketShard.ts
+++ b/packages/ws/src/WebSocketShard.ts
@@ -148,6 +148,8 @@ export class WebSocketShard extends EventEmitter {
   private heartbeatTimeout: ReturnType<typeof setTimeout> | null = null;
   /** True until a heartbeat is sent; cleared by HeartbeatAck. */
   private lastHeartbeatAck = true;
+  private heartbeatSentAt: number | null = null;
+  private _ping: number | null = null;
   private sessionId: string | null = null;
   private seq: number | null = null;
   private reconnectDelayMs = RECONNECT_INITIAL_MS;
@@ -165,6 +167,11 @@ export class WebSocketShard extends EventEmitter {
     return this.options.shardId;
   }
 
+  /** Latest heartbeat round-trip latency in milliseconds. */
+  get ping(): number | null {
+    return this._ping;
+  }
+
   /** Mapped readyState: 0 idle/closed, 1 connecting, 2 open, 3 closing. */
   get status(): number {
     if (!this.ws) return 0;
@@ -178,6 +185,7 @@ export class WebSocketShard extends EventEmitter {
 
     this.clearReconnectTimer();
     this.phase = Phase.Connecting;
+    this.resetHeartbeatLatency();
     this.debug('Connecting');
 
     try {
@@ -206,6 +214,7 @@ export class WebSocketShard extends EventEmitter {
     this.phase = Phase.Destroyed;
     this.clearReconnectTimer();
     this.stopHeartbeat();
+    this.resetHeartbeatLatency();
     this.ws?.close(1000);
     this.ws = null;
     this.sessionId = null;
@@ -220,6 +229,10 @@ export class WebSocketShard extends EventEmitter {
         break;
       case GatewayOpcodes.HeartbeatAck:
         this.lastHeartbeatAck = true;
+        if (this.heartbeatSentAt !== null) {
+          this._ping = Math.max(0, Math.round(performance.now() - this.heartbeatSentAt));
+          this.heartbeatSentAt = null;
+        }
         break;
       case GatewayOpcodes.Dispatch:
         this.handleDispatch(payload);
@@ -296,6 +309,7 @@ export class WebSocketShard extends EventEmitter {
     this.phase = Phase.Idle;
     this.ws = null;
     this.stopHeartbeat();
+    this.resetHeartbeatLatency();
     this.emit('close', code);
     this.debug(`Closed: ${code}`);
     if (shouldReconnectOnClose(code)) this.scheduleReconnect();
@@ -312,6 +326,7 @@ export class WebSocketShard extends EventEmitter {
     }
     this.ws = null;
     this.stopHeartbeat();
+    this.resetHeartbeatLatency();
     this.debug('Connection error; will retry…');
     this.scheduleReconnect();
   }
@@ -384,8 +399,15 @@ export class WebSocketShard extends EventEmitter {
       this.ws?.close(1000);
       return;
     }
+    if (this.ws?.readyState !== 1) return;
     this.lastHeartbeatAck = false;
-    this.send({ op: GatewayOpcodes.Heartbeat, d: this.seq ?? null });
+    this.ws.send(
+      JSON.stringify({
+        op: GatewayOpcodes.Heartbeat,
+        d: this.seq ?? null,
+      } satisfies GatewaySendPayload),
+    );
+    this.heartbeatSentAt ??= performance.now();
   }
 
   private stopHeartbeat(): void {
@@ -397,6 +419,11 @@ export class WebSocketShard extends EventEmitter {
       clearInterval(this.heartbeatInterval);
       this.heartbeatInterval = null;
     }
+  }
+
+  private resetHeartbeatLatency(): void {
+    this.heartbeatSentAt = null;
+    this._ping = null;
   }
 
   private scheduleReconnect(): void {


### PR DESCRIPTION
## Description

<!-- Describe your changes -->

Adds two convenient values for bot authors:

- `client.uptime` shows how long the client has been ready
- `client.ws.ping` shows the current gateway connection latency

`client.uptime` can be read at any time. `client.ws.ping` is available after login has started.

### How it works

```mermaid
flowchart LR
    A[Bot connects] --> B[Client becomes ready]
    B --> C[client.uptime starts]
    A --> D[Client sends heartbeat]
    D --> E[Gateway acknowledges heartbeat]
    E --> F[client.ws.ping updates]
```

### Expected behavior

| State | `client.uptime` | `client.ws.ping` |
| --- | --- | --- |
| Before login | `null` | Accessing `client.ws` throws `NotLoggedIn` |
| Login started, before READY or the first heartbeat response | `null` | `null` |
| Connected after heartbeat responses | Number in milliseconds | Average available latency in milliseconds |
| One or more shards reconnect | Continues until another READY updates it | Averages shards with current samples, or `null` if none have a sample |
| Client is destroyed | `null` | Accessing `client.ws` throws `NotLoggedIn` |

### Why gateway heartbeat latency

A request to `/gateway/bot` measures a REST API request. It does not measure the active gateway connection.

Gateway latency is now calculated from the time between sending a heartbeat and receiving its acknowledgement.

For bots using multiple shards, `client.ws.ping` averages shards with a current heartbeat sample. Shards that are still connecting or reconnecting are skipped. The value is `null` only when no managed shard has a current sample.

### Additional changes

- Updated the ping bot example to use the new properties
- Added focused tests for uptime, heartbeat latency, shard averaging, and reset behavior
- Added a changeset for `@fluxerjs/core` and `@fluxerjs/ws`

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] My code follows the project's style guidelines (run `pnpm run lint`)
- [x] I have run `pnpm run build` successfully
- [x] I have run `pnpm run test` successfully

